### PR TITLE
Replace solidity terms with hyperion part 2 + console log filter fix

### DIFF
--- a/cmd/abigen/namefilter.go
+++ b/cmd/abigen/namefilter.go
@@ -6,8 +6,8 @@ import (
 )
 
 type nameFilter struct {
-	fulls map[string]bool // path/to/contract.sol:Type
-	files map[string]bool // path/to/contract.sol:*
+	fulls map[string]bool // path/to/contract.hyp:Type
+	files map[string]bool // path/to/contract.hyp:*
 	types map[string]bool // *:Type
 }
 

--- a/common/compiler/hyperion.go
+++ b/common/compiler/hyperion.go
@@ -35,12 +35,12 @@ type hypcOutput struct {
 	Version string
 }
 
-// ParseCombinedJSON takes the direct output of a solc --combined-output run and
+// ParseCombinedJSON takes the direct output of a hypc --combined-output run and
 // parses it into a map of string contract name to Contract structs. The
 // provided source, language and compiler version, and compiler options are all
 // passed through into the Contract structs.
 //
-// The solc output is expected to contain ABI, source mapping, user docs, and dev docs.
+// The hypc output is expected to contain ABI, source mapping, user docs, and dev docs.
 //
 // Returns an error if the JSON is malformed or missing data, or if the JSON
 // embedded within the JSON is malformed.

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3324,7 +3324,7 @@ HyperionEvent.prototype.execute = function (indexed, options, callback) {
 
     var o = this.encode(indexed, options);
     var formatter = this.decode.bind(this);
-    return new Filter(o, 'eth', this._requestManager, watches.eth(), formatter, callback);
+    return new Filter(o, 'zond', this._requestManager, watches.zond(), formatter, callback);
 };
 
 /**
@@ -3458,7 +3458,7 @@ var getOptions = function (options, type) {
 
 
     switch(type) {
-        case 'eth':
+        case 'zond':
 
             // make sure topics, get converted to hex
             options.topics = options.topics || [];
@@ -5432,7 +5432,7 @@ Zond.prototype.contract = function (abi) {
 };
 
 Zond.prototype.filter = function (options, callback, filterCreationErrorCallback) {
-    return new Filter(options, 'eth', this._requestManager, watches.eth(), formatters.outputLogFormatter, callback, filterCreationErrorCallback);
+    return new Filter(options, 'zond', this._requestManager, watches.zond(), formatters.outputLogFormatter, callback, filterCreationErrorCallback);
 };
 
 Zond.prototype.namereg = function () {

--- a/signer/fourbyte/abi.go
+++ b/signer/fourbyte/abi.go
@@ -37,7 +37,7 @@ type decodedCallData struct {
 // decodedArgument is an internal type to represent an argument parsed according
 // to an ABI method signature.
 type decodedArgument struct {
-	soltype abi.Argument
+	hyptype abi.Argument
 	value   interface{}
 }
 
@@ -50,7 +50,7 @@ func (arg decodedArgument) String() string {
 	default:
 		value = fmt.Sprintf("%v", val)
 	}
-	return fmt.Sprintf("%v: %v", arg.soltype.Type.String(), value)
+	return fmt.Sprintf("%v: %v", arg.hyptype.Type.String(), value)
 }
 
 // String implements stringer interface for decodedCallData
@@ -115,7 +115,7 @@ func parseCallData(calldata []byte, unescapedAbidata string) (*decodedCallData, 
 	decoded := decodedCallData{signature: method.Sig, name: method.RawName}
 	for i := 0; i < len(method.Inputs); i++ {
 		decoded.inputs = append(decoded.inputs, decodedArgument{
-			soltype: method.Inputs[i],
+			hyptype: method.Inputs[i],
 			value:   values[i],
 		})
 	}

--- a/tests/hyperion/migrations/2_opCodes_migration.js
+++ b/tests/hyperion/migrations/2_opCodes_migration.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-var OpCodes = artifacts.require("./OpCodes.sol");
+var OpCodes = artifacts.require("./OpCodes.hyp");
 
 module.exports = function(deployer) {
   deployer.deploy(OpCodes);

--- a/tests/hyperion/test/opCodes.js
+++ b/tests/hyperion/test/opCodes.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-const TodoList = artifacts.require('./OpCodes.sol')
+const TodoList = artifacts.require('./OpCodes.hyp')
 const assert = require('assert')
 let contractInstance
 const Web3 = require('web3');


### PR DESCRIPTION
## TEST

**console log filters manual tests**

Tests can be found [here](https://github.com/rgeraldes24/qrl-docs/blob/main/theqrl.org/release/v0.1.1/cyyber/go-zond/pull/22/README.md)

**unit tests**

```
go test -count=1 ./...

?   	github.com/theQRL/go-zond	[no test files]
?   	github.com/theQRL/go-zond/accounts/external	[no test files]
?   	github.com/theQRL/go-zond/accounts/scwallet	[no test files]
?   	github.com/theQRL/go-zond/accounts/usbwallet	[no test files]
?   	github.com/theQRL/go-zond/accounts/usbwallet/trezor	[no test files]
?   	github.com/theQRL/go-zond/beacon/engine	[no test files]
?   	github.com/theQRL/go-zond/beacon/params	[no test files]
?   	github.com/theQRL/go-zond/cmd/abidump	[no test files]
ok  	github.com/theQRL/go-zond/accounts	0.624s
ok  	github.com/theQRL/go-zond/accounts/abi	0.877s
ok  	github.com/theQRL/go-zond/accounts/abi/bind	0.643s
ok  	github.com/theQRL/go-zond/accounts/abi/bind/backends	0.959s
?   	github.com/theQRL/go-zond/cmd/bootnode	[no test files]
?   	github.com/theQRL/go-zond/cmd/devp2p/internal/v4test	[no test files]
?   	github.com/theQRL/go-zond/cmd/devp2p/internal/v5test	[no test files]
?   	github.com/theQRL/go-zond/cmd/p2psim	[no test files]
?   	github.com/theQRL/go-zond/cmd/zvm/internal/compiler	[no test files]
?   	github.com/theQRL/go-zond/cmd/zvm/internal/t8ntool	[no test files]
?   	github.com/theQRL/go-zond/common/compiler	[no test files]
?   	github.com/theQRL/go-zond/consensus	[no test files]
?   	github.com/theQRL/go-zond/consensus/beacon	[no test files]
?   	github.com/theQRL/go-zond/consensus/misc	[no test files]
?   	github.com/theQRL/go-zond/console/prompt	[no test files]
?   	github.com/theQRL/go-zond/core/state/pruner	[no test files]
?   	github.com/theQRL/go-zond/core/txpool	[no test files]
ok  	github.com/theQRL/go-zond/accounts/keystore	9.127s
ok  	github.com/theQRL/go-zond/cmd/abigen	0.408s
ok  	github.com/theQRL/go-zond/cmd/clef	0.736s
ok  	github.com/theQRL/go-zond/cmd/devp2p	0.833s
ok  	github.com/theQRL/go-zond/cmd/devp2p/internal/zondtest	1.059s [no tests to run]
?   	github.com/theQRL/go-zond/crypto/bn256	[no test files]
?   	github.com/theQRL/go-zond/crypto/pqcrypto	[no test files]
?   	github.com/theQRL/go-zond/graphql/internal/graphiql	[no test files]
?   	github.com/theQRL/go-zond/internal/blocktest	[no test files]
?   	github.com/theQRL/go-zond/internal/build	[no test files]
?   	github.com/theQRL/go-zond/internal/cmdtest	[no test files]
?   	github.com/theQRL/go-zond/internal/debug	[no test files]
?   	github.com/theQRL/go-zond/internal/jsre/deps	[no test files]
?   	github.com/theQRL/go-zond/internal/shutdowncheck	[no test files]
?   	github.com/theQRL/go-zond/internal/syncx	[no test files]
?   	github.com/theQRL/go-zond/internal/testlog	[no test files]
?   	github.com/theQRL/go-zond/internal/version	[no test files]
?   	github.com/theQRL/go-zond/internal/web3ext	[no test files]
?   	github.com/theQRL/go-zond/metrics/exp	[no test files]
ok  	github.com/theQRL/go-zond/cmd/gzond	22.682s
ok  	github.com/theQRL/go-zond/cmd/rlpdump	0.267s
ok  	github.com/theQRL/go-zond/cmd/utils	0.998s
ok  	github.com/theQRL/go-zond/cmd/zondkey	0.921s
ok  	github.com/theQRL/go-zond/cmd/zvm	1.473s
ok  	github.com/theQRL/go-zond/common	0.967s
ok  	github.com/theQRL/go-zond/common/bitutil	1.425s
ok  	github.com/theQRL/go-zond/common/fdlimit	1.611s
ok  	github.com/theQRL/go-zond/common/hexutil	1.448s
ok  	github.com/theQRL/go-zond/common/lru	1.308s
ok  	github.com/theQRL/go-zond/common/math	1.480s
ok  	github.com/theQRL/go-zond/common/mclock	1.238s
ok  	github.com/theQRL/go-zond/common/prque	1.844s
ok  	github.com/theQRL/go-zond/consensus/misc/eip1559	1.300s
ok  	github.com/theQRL/go-zond/console	1.596s
?   	github.com/theQRL/go-zond/p2p/simulations/examples	[no test files]
?   	github.com/theQRL/go-zond/p2p/simulations/pipes	[no test files]
?   	github.com/theQRL/go-zond/p2p/tracker	[no test files]
?   	github.com/theQRL/go-zond/rlp/internal/rlpstruct	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/bitutil	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/keystore	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/rangeproof	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/rangeproof/debug	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/rlp	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/runtime	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/snap	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/snap/debug	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/stacktrie	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/stacktrie/debug	[no test files]
?   	github.com/theQRL/go-zond/tests/fuzzers/trie	[no test files]
?   	github.com/theQRL/go-zond/trie/testutil	[no test files]
?   	github.com/theQRL/go-zond/trie/triedb/hashdb	[no test files]
ok  	github.com/theQRL/go-zond/core	25.272s
ok  	github.com/theQRL/go-zond/core/asm	0.947s
ok  	github.com/theQRL/go-zond/core/bloombits	1.870s
ok  	github.com/theQRL/go-zond/core/forkid	1.405s
ok  	github.com/theQRL/go-zond/core/rawdb	18.826s
ok  	github.com/theQRL/go-zond/core/state	5.859s
ok  	github.com/theQRL/go-zond/core/state/snapshot	6.876s
ok  	github.com/theQRL/go-zond/core/txpool/legacypool	21.662s
ok  	github.com/theQRL/go-zond/core/types	2.192s
ok  	github.com/theQRL/go-zond/core/vm	0.356s
ok  	github.com/theQRL/go-zond/core/vm/runtime	0.363s
ok  	github.com/theQRL/go-zond/crypto	0.315s
ok  	github.com/theQRL/go-zond/crypto/bn256/cloudflare	0.360s
ok  	github.com/theQRL/go-zond/crypto/bn256/google	0.562s
ok  	github.com/theQRL/go-zond/crypto/ecies	0.273s
ok  	github.com/theQRL/go-zond/crypto/secp256k1	0.557s
ok  	github.com/theQRL/go-zond/crypto/signify	0.548s
ok  	github.com/theQRL/go-zond/event	0.979s
ok  	github.com/theQRL/go-zond/graphql	0.444s
ok  	github.com/theQRL/go-zond/internal/flags	0.324s
ok  	github.com/theQRL/go-zond/internal/guide	1.105s
ok  	github.com/theQRL/go-zond/internal/jsre	0.615s
ok  	github.com/theQRL/go-zond/internal/utesting	0.637s
ok  	github.com/theQRL/go-zond/internal/zondapi	0.342s
ok  	github.com/theQRL/go-zond/log	0.561s
ok  	github.com/theQRL/go-zond/metrics	6.295s
ok  	github.com/theQRL/go-zond/metrics/influxdb	0.467s
ok  	github.com/theQRL/go-zond/metrics/internal	0.719s
ok  	github.com/theQRL/go-zond/metrics/prometheus	0.669s
ok  	github.com/theQRL/go-zond/miner	1.536s
ok  	github.com/theQRL/go-zond/node	3.191s
ok  	github.com/theQRL/go-zond/p2p	1.648s
?   	github.com/theQRL/go-zond/trie/trienode	[no test files]
?   	github.com/theQRL/go-zond/trie/triestate	[no test files]
?   	github.com/theQRL/go-zond/zond/tracers/js/internal/tracers	[no test files]
?   	github.com/theQRL/go-zond/zond/tracers/native	[no test files]
?   	github.com/theQRL/go-zond/zond/zondconfig	[no test files]
?   	github.com/theQRL/go-zond/zonddb	[no test files]
?   	github.com/theQRL/go-zond/zonddb/dbtest	[no test files]
?   	github.com/theQRL/go-zond/zonddb/remotedb	[no test files]
ok  	github.com/theQRL/go-zond/p2p/discover	65.952s
ok  	github.com/theQRL/go-zond/p2p/discover/v4wire	0.280s
ok  	github.com/theQRL/go-zond/p2p/discover/v5wire	0.287s
ok  	github.com/theQRL/go-zond/p2p/dnsdisc	1.027s
ok  	github.com/theQRL/go-zond/p2p/enode	1.589s
ok  	github.com/theQRL/go-zond/p2p/enr	0.456s
ok  	github.com/theQRL/go-zond/p2p/msgrate	0.271s
ok  	github.com/theQRL/go-zond/p2p/nat	2.789s
ok  	github.com/theQRL/go-zond/p2p/netutil	0.365s
ok  	github.com/theQRL/go-zond/p2p/nodestate	0.703s
ok  	github.com/theQRL/go-zond/p2p/rlpx	0.549s
ok  	github.com/theQRL/go-zond/p2p/simulations	1.738s
ok  	github.com/theQRL/go-zond/p2p/simulations/adapters	0.320s
ok  	github.com/theQRL/go-zond/params	0.474s
ok  	github.com/theQRL/go-zond/rlp	0.662s
ok  	github.com/theQRL/go-zond/rlp/rlpgen	1.226s
ok  	github.com/theQRL/go-zond/rpc	18.706s
ok  	github.com/theQRL/go-zond/signer/core	3.910s
ok  	github.com/theQRL/go-zond/signer/core/apitypes	0.657s
ok  	github.com/theQRL/go-zond/signer/fourbyte	3.792s
ok  	github.com/theQRL/go-zond/signer/rules	0.416s
ok  	github.com/theQRL/go-zond/signer/storage	0.551s
ok  	github.com/theQRL/go-zond/tests	0.302s
ok  	github.com/theQRL/go-zond/tests/fuzzers/abi	0.555s
ok  	github.com/theQRL/go-zond/tests/fuzzers/secp256k1	0.281s
ok  	github.com/theQRL/go-zond/tests/fuzzers/txfetcher	0.376s
ok  	github.com/theQRL/go-zond/trie	30.193s
ok  	github.com/theQRL/go-zond/trie/triedb/pathdb	4.061s
ok  	github.com/theQRL/go-zond/zond	1.780s
ok  	github.com/theQRL/go-zond/zond/catalyst	3.371s
ok  	github.com/theQRL/go-zond/zond/downloader	8.075s
ok  	github.com/theQRL/go-zond/zond/fetcher	2.464s
ok  	github.com/theQRL/go-zond/zond/filters	1.487s
ok  	github.com/theQRL/go-zond/zond/gasprice	1.602s
ok  	github.com/theQRL/go-zond/zond/protocols/snap	13.823s
ok  	github.com/theQRL/go-zond/zond/protocols/zond	0.444s
ok  	github.com/theQRL/go-zond/zond/tracers	2.526s
ok  	github.com/theQRL/go-zond/zond/tracers/internal/tracetest	0.375s
ok  	github.com/theQRL/go-zond/zond/tracers/js	1.619s
ok  	github.com/theQRL/go-zond/zond/tracers/logger	0.302s
ok  	github.com/theQRL/go-zond/zondclient	2.386s
ok  	github.com/theQRL/go-zond/zondclient/gzondclient	0.678s
ok  	github.com/theQRL/go-zond/zonddb/leveldb	0.596s
ok  	github.com/theQRL/go-zond/zonddb/memorydb	0.844s
ok  	github.com/theQRL/go-zond/zonddb/pebble	0.288s
ok  	github.com/theQRL/go-zond/zondstats	0.310s
```


**qrysm e2e** 

```
bazel test //testing/endtoend:go_default_test --//proto:network=minimal --test_filter=TestEndToEnd_MinimalConfig --test_output=streamed --cache_test_results=no

--- PASS: TestEndToEnd_MinimalConfig (852.94s)
    --- PASS: TestEndToEnd_MinimalConfig/chain_started (2.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_0 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_0 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_connect_epoch_0 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_0 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_1 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_1 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_1 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_1 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_1 (0.21s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_2 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_2 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/api_gateway_v1alpha1_verify_integrity_epoch_2 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_2 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_2 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_2 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_3 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_3 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_3 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_3 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_3 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_4 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_4 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposits_in_blocks_epoch_4 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_4 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_4 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_4 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_5 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_5 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_5 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_5 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_5 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/api_middleware_verify_integrity_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_6 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_6 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_6 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_7 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_7 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_7 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_7 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_7 (0.13s)
    --- PASS: TestEndToEnd_MinimalConfig/propose_voluntary_exit_epoch_7 (0.19s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_7 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/voluntary_has_exited_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_8 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_8 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_8 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_9 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_9 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_9 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_9 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_9 (0.05s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_9 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_9 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/submit_withdrawal_epoch_9 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_9 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_10 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_10 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_10 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_10 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_10 (0.05s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_10 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_10 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/submit_withdrawal_epoch_10 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_10 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_has_withdrawn_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_11 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_11 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_11 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_11 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/sync_completed (0.50s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_%d (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_%d (0.16s)
    --- PASS: TestEndToEnd_MinimalConfig/doppelganger_found (0.50s)
PASS
Target //testing/endtoend:go_default_test up-to-date:
  bazel-bin/testing/endtoend/go_default_test_/go_default_test
INFO: Elapsed time: 859.134s, Critical Path: 857.05s
INFO: 23 processes: 16 internal, 7 darwin-sandbox.
INFO: Build completed successfully, 23 total actions
//testing/endtoend:go_default_test                                       PASSED in 854.5s
  WARNING: //testing/endtoend:go_default_test: Test execution time (854.5s excluding execution overhead) outside of range for LONG tests. Consider setting timeout="eternal" or size="enormous".

Executed 1 out of 1 test: 1 test passes.
```