### PR TITLE
[FIX] Remove lossy address hash helper

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -445,9 +445,6 @@ func (a Address) Cmp(other Address) int {
 // Bytes gets the string representation of the underlying address.
 func (a Address) Bytes() []byte { return a[:] }
 
-// Hash converts an address to a hash by left-padding it with zeros.
-func (a Address) Hash() Hash { return BytesToHash(a[:]) }
-
 // Big converts an address to a big integer.
 func (a Address) Big() *big.Int { return new(big.Int).SetBytes(a[:]) }
 


### PR DESCRIPTION
## Summary

- Remove `common.Address.Hash()` because it is a lossy conversion: converting a 64-byte QRL address into a 32-byte `common.Hash` drops the upper 32 bytes of the address.

This is a small extraction from the broader VM64 cleanup. Follow-up PRs can handle the remaining ABI, RPC, fixture, and console updates separately.

## Tests

- `go test ./...`