### PR TITLE
[FIX] Fix receipt log topic size

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -208,7 +208,7 @@ func (r *Receipt) Size() common.StorageSize {
 	size := common.StorageSize(unsafe.Sizeof(*r)) + common.StorageSize(len(r.PostState))
 	size += common.StorageSize(len(r.Logs)) * common.StorageSize(unsafe.Sizeof(Log{}))
 	for _, log := range r.Logs {
-		size += common.StorageSize(len(log.Topics)*common.HashLength + len(log.Data))
+		size += common.StorageSize(len(log.Topics)*common.LogTopicLength + len(log.Data))
 	}
 	return size
 }

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -224,6 +224,25 @@ func TestDecodeEmptyTypedReceipt(t *testing.T) {
 	}
 }
 
+func TestReceiptSizeCountsLogTopicLength(t *testing.T) {
+	withoutTopic := (&Receipt{
+		Logs: []*Log{{
+			Data: []byte{0x01, 0x02, 0x03},
+		}},
+	}).Size()
+
+	withTopic := (&Receipt{
+		Logs: []*Log{{
+			Topics: []common.LogTopic{{}},
+			Data:   []byte{0x01, 0x02, 0x03},
+		}},
+	}).Size()
+
+	if diff := withTopic - withoutTopic; diff != common.StorageSize(common.LogTopicLength) {
+		t.Fatalf("receipt topic size mismatch: have %d, want %d", uint64(diff), common.LogTopicLength)
+	}
+}
+
 // Tests that receipt data can be correctly derived from the contextual infos
 func TestDeriveFields(t *testing.T) {
 	// Re-derive receipts.


### PR DESCRIPTION
## Summary

- Fix `Receipt.Size()` to count log topics using the full 64-byte `common.LogTopicLength`.
- Previously, receipt size accounting used `common.HashLength`, so each log topic was counted as 32 bytes instead of 64 bytes.

This is a small extraction from the broader VM64 cleanup. Follow-up PRs can handle the remaining ABI, RPC, fixture, and console updates separately.

## Tests

- `go test ./...`