### PR TITLE
[REFACTOR] Add VM word size constants

### DIFF
--- a/common/uint512/uint512.go
+++ b/common/uint512/uint512.go
@@ -14,6 +14,13 @@ import (
 	"math/bits"
 )
 
+const (
+	// WordBits is the width of Int in bits.
+	WordBits = 512
+	// WordBytes is the width of Int in bytes.
+	WordBytes = WordBits / 8
+)
+
 // Int is a 512-bit unsigned integer stored as 8 little-endian 64-bit limbs.
 //
 // z[0] is bits 0..63, z[7] is bits 448..511. The zero value represents 0.
@@ -182,14 +189,14 @@ func (z *Int) SetUint64(v uint64) *Int {
 // truncates to 512 bits if longer (keeping the least-significant bytes),
 // and sets z. Returns z.
 func (z *Int) SetBytes(buf []byte) *Int {
-	if len(buf) > 64 {
-		buf = buf[len(buf)-64:]
+	if len(buf) > WordBytes {
+		buf = buf[len(buf)-WordBytes:]
 	}
 	// Zero the destination first.
 	*z = Int{}
 	// Copy bytes into a temporary 64-byte buffer, right-aligned.
-	var tmp [64]byte
-	copy(tmp[64-len(buf):], buf)
+	var tmp [WordBytes]byte
+	copy(tmp[WordBytes-len(buf):], buf)
 	// tmp is big-endian: tmp[0..7] are the most-significant 8 bytes (limb 7).
 	for i := 0; i < 8; i++ {
 		// limb i (little-endian) comes from tmp bytes (7-i)*8 .. (7-i)*8+7.
@@ -205,7 +212,7 @@ func (z *Int) SetBytes(buf []byte) *Int {
 // SetFromBig sets z to b mod 2^512 and reports whether b was outside
 // [0, 2^512).
 func (z *Int) SetFromBig(b *big.Int) bool {
-	overflow := b.Sign() < 0 || b.BitLen() > 512
+	overflow := b.Sign() < 0 || b.BitLen() > WordBits
 	if overflow {
 		// Reduce to [0, 2^512).
 		tmp := new(big.Int).And(b, mask512())
@@ -220,11 +227,11 @@ func (z *Int) SetFromBig(b *big.Int) bool {
 func (z *Int) setFromBigUnsafe(b *big.Int) {
 	*z = Int{}
 	bytes := b.Bytes() // big-endian
-	if len(bytes) > 64 {
-		bytes = bytes[len(bytes)-64:]
+	if len(bytes) > WordBytes {
+		bytes = bytes[len(bytes)-WordBytes:]
 	}
-	var tmp [64]byte
-	copy(tmp[64-len(bytes):], bytes)
+	var tmp [WordBytes]byte
+	copy(tmp[WordBytes-len(bytes):], bytes)
 	for i := 0; i < 8; i++ {
 		off := (7 - i) * 8
 		z[i] = uint64(tmp[off])<<56 | uint64(tmp[off+1])<<48 |
@@ -273,7 +280,7 @@ func (z *Int) ToBig() *big.Int {
 // bytes64Slice returns the 64-byte big-endian representation of z as a slice,
 // without the leading-zero stripping done by Bytes().
 func (z *Int) bytes64Slice() []byte {
-	out := make([]byte, 64)
+	out := make([]byte, WordBytes)
 	for i := 0; i < 8; i++ {
 		off := (7 - i) * 8
 		v := z[i]
@@ -323,8 +330,8 @@ func (z *Int) Bytes32() [32]byte {
 }
 
 // Bytes64 returns the 64-byte big-endian representation of z.
-func (z *Int) Bytes64() [64]byte {
-	var out [64]byte
+func (z *Int) Bytes64() [WordBytes]byte {
+	var out [WordBytes]byte
 	for i := 0; i < 8; i++ {
 		off := (7 - i) * 8
 		v := z[i]
@@ -500,7 +507,7 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 // ExtendSign sets z to x sign-extended from byte position (byteNum+1) to
 // 512 bits. Matches the semantics of EVM SIGNEXTEND but for 64-byte words.
 func (z *Int) ExtendSign(x, byteNum *Int) *Int {
-	if !byteNum.IsUint64() || byteNum[0] >= 63 {
+	if !byteNum.IsUint64() || byteNum[0] >= WordBytes-1 {
 		if z != x {
 			*z = *x
 		}
@@ -511,7 +518,7 @@ func (z *Int) ExtendSign(x, byteNum *Int) *Int {
 
 	// Bits below and including the sign bit are preserved; bits above are
 	// filled with the sign value.
-	signSet := (x[bit/64] >> (bit % 64)) & 1 != 0
+	signSet := (x[bit/64]>>(bit%64))&1 != 0
 
 	// Build mask = 2^(bit+1) - 1.
 	var mask Int
@@ -600,7 +607,7 @@ func (z *Int) Not(x *Int) *Int {
 
 // Lsh sets z = x << n (mod 2^512) and returns z.
 func (z *Int) Lsh(x *Int, n uint) *Int {
-	if n >= 512 {
+	if n >= WordBits {
 		z.Clear()
 		return z
 	}
@@ -630,7 +637,7 @@ func (z *Int) Lsh(x *Int, n uint) *Int {
 
 // Rsh sets z = x >> n (logical shift right) and returns z.
 func (z *Int) Rsh(x *Int, n uint) *Int {
-	if n >= 512 {
+	if n >= WordBits {
 		z.Clear()
 		return z
 	}
@@ -663,7 +670,7 @@ func (z *Int) SRsh(x *Int, n uint) *Int {
 	if x[7]>>63 == 0 {
 		return z.Rsh(x, n)
 	}
-	if n >= 512 {
+	if n >= WordBits {
 		return z.SetAllOne()
 	}
 	if n == 0 {
@@ -673,7 +680,7 @@ func (z *Int) SRsh(x *Int, n uint) *Int {
 	// For negative numbers: rshift normally, then fill the top `n` bits with 1s.
 	z.Rsh(x, n)
 	// OR in the sign-extended bits.
-	bit := uint(512) - n // first bit index (from LSB) that should be 1
+	bit := uint(WordBits) - n // first bit index (from LSB) that should be 1
 	for i := int(bit) / 64; i < 8; i++ {
 		var mask uint64
 		if i == int(bit)/64 {
@@ -690,15 +697,15 @@ func (z *Int) SRsh(x *Int, n uint) *Int {
 // 0 is the most significant byte of the 64-byte representation. If n >= 64, z
 // is set to 0.
 func (z *Int) Byte(n *Int) *Int {
-	if !n.IsUint64() || n[0] >= 64 {
+	if !n.IsUint64() || n[0] >= WordBytes {
 		z.Clear()
 		return z
 	}
 	idx := n[0]
-	// Big-endian index `idx` corresponds to bit position 8*(63-idx) in the
-	// little-endian limb layout. Limb = (63-idx)/8 from the bottom, byte
-	// within limb = (63-idx)%8 from the bottom.
-	be := 63 - idx
+	// Big-endian index `idx` corresponds to bit position 8*(WordBytes-1-idx)
+	// in the little-endian limb layout. Limb = (WordBytes-1-idx)/8 from the
+	// bottom, byte within limb = (WordBytes-1-idx)%8 from the bottom.
+	be := WordBytes - 1 - idx
 	limb := be / 8
 	byteInLimb := be % 8
 	b := (z[limb] >> (byteInLimb * 8)) & 0xff
@@ -711,7 +718,7 @@ func (z *Int) Byte(n *Int) *Int {
 // modulus returns a fresh 2^512 big.Int. Allocated per call to avoid shared
 // mutable state with callers that mutate the returned value.
 func modulus() *big.Int {
-	return new(big.Int).Lsh(big.NewInt(1), 512)
+	return new(big.Int).Lsh(big.NewInt(1), WordBits)
 }
 
 // mask512 returns a fresh (2^512 - 1) big.Int.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -112,11 +112,12 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 
 // toWordSize returns the ceiled word size required for init code payment calculation.
 func toWordSize(size uint64) uint64 {
-	if size > math.MaxUint64-63 {
-		return math.MaxUint64/64 + 1
+	const wordBytes = uint64(vm.WordBytes)
+	if size > math.MaxUint64-(wordBytes-1) {
+		return math.MaxUint64/wordBytes + 1
 	}
 
-	return (size + 63) / 64
+	return (size + wordBytes - 1) / wordBytes
 }
 
 // A Message contains the data derived from a single transaction that is relevant to state

--- a/core/vm/common.go
+++ b/core/vm/common.go
@@ -23,6 +23,13 @@ import (
 	"github.com/theQRL/go-qrl/common/uint512"
 )
 
+const (
+	// WordBits is the VM word width in bits.
+	WordBits = uint512.WordBits
+	// WordBytes is the VM word width in bytes.
+	WordBytes = uint512.WordBytes
+)
+
 // calcMemSize64 calculates the required memory size, and returns
 // the size and whether the result overflowed uint64
 func calcMemSize64(off, l *uint512.Int) (uint64, bool) {
@@ -62,16 +69,17 @@ func getData(data []byte, start uint64, size uint64) []byte {
 }
 
 // toWordSize returns the ceiled word size required for memory expansion.
-// The VM word is 64 bytes.
+// The VM word is WordBytes bytes.
 func toWordSize(size uint64) uint64 {
-	if size > math.MaxUint64-63 {
-		return math.MaxUint64/64 + 1
+	const wordBytes = uint64(WordBytes)
+	if size > math.MaxUint64-(wordBytes-1) {
+		return math.MaxUint64/wordBytes + 1
 	}
 
-	return (size + 63) / 64
+	return (size + wordBytes - 1) / wordBytes
 }
 
-// stackToAddress extracts a 64-byte address from a 512-bit stack value.
+// stackToAddress extracts an address from a stack word.
 func stackToAddress(val *uint512.Int) common.Address {
 	b := val.Bytes64()
 	return common.BytesToAddress(b[:])

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -36,7 +36,7 @@ func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 		return 0, ErrGasUintOverflow
 	}
 	newMemSizeWords := toWordSize(newMemSize)
-	newMemSize = newMemSizeWords * 64
+	newMemSize = newMemSizeWords * WordBytes
 
 	if newMemSize > uint64(mem.Len()) {
 		square := newMemSizeWords * newMemSizeWords
@@ -190,7 +190,7 @@ func gasExpEIP158(qrvm *QRVM, contract *Contract, stack *Stack, mem *Memory, mem
 	expByteLen := uint64((stack.data[stack.len()-2].BitLen() + 7) / 8)
 
 	var (
-		gas      = expByteLen * params.ExpByteEIP158 // no overflow check required. Max is 512 * ExpByte gas
+		gas      = expByteLen * params.ExpByteEIP158 // no overflow check required. Max is one VM word * ExpByte gas
 		overflow bool
 	)
 	if gas, overflow = math.SafeAdd(gas, params.ExpGas); overflow {

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -192,7 +192,7 @@ func opMulmod(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]
 func opSHL(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
 	shift, value := scope.Stack.pop(), scope.Stack.peek()
-	if shift.LtUint64(512) {
+	if shift.LtUint64(WordBits) {
 		value.Lsh(value, uint(shift.Uint64()))
 	} else {
 		value.Clear()
@@ -206,7 +206,7 @@ func opSHL(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byt
 func opSHR(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
 	shift, value := scope.Stack.pop(), scope.Stack.peek()
-	if shift.LtUint64(512) {
+	if shift.LtUint64(WordBits) {
 		value.Rsh(value, uint(shift.Uint64()))
 	} else {
 		value.Clear()
@@ -219,7 +219,7 @@ func opSHR(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byt
 // and pushes on the stack arg2 shifted to the right by arg1 number of bits with sign extension.
 func opSAR(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	shift, value := scope.Stack.pop(), scope.Stack.peek()
-	if shift.GtUint64(512) {
+	if shift.GtUint64(WordBits) {
 		if value.Sign() >= 0 {
 			value.Clear()
 		} else {
@@ -283,7 +283,7 @@ func opCallValue(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) 
 func opCallDataLoad(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x := scope.Stack.peek()
 	if offset, overflow := x.Uint64WithOverflow(); !overflow {
-		data := getData(scope.Contract.Input, offset, 64)
+		data := getData(scope.Contract.Input, offset, WordBytes)
 		x.SetBytes(data)
 	} else {
 		x.Clear()
@@ -489,7 +489,7 @@ func opPop(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byt
 func opMload(pc *uint64, interpreter *QRVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	v := scope.Stack.peek()
 	offset := int64(v.Uint64())
-	v.SetBytes(scope.Memory.GetPtr(offset, 64))
+	v.SetBytes(scope.Memory.GetPtr(offset, WordBytes))
 	return nil, nil
 }
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -173,9 +173,9 @@ func (in *QRVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) 
 				if overflow {
 					return nil, ErrGasUintOverflow
 				}
-				// memory is expanded in words of 64 bytes. Gas
+				// memory is expanded in VM words. Gas
 				// is also calculated in words.
-				if memorySize, overflow = math.SafeMul(toWordSize(memSize), 64); overflow {
+				if memorySize, overflow = math.SafeMul(toWordSize(memSize), uint64(WordBytes)); overflow {
 					return nil, ErrGasUintOverflow
 				}
 			}

--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -45,12 +45,11 @@ func (m *Memory) Set(offset, size uint64, value []byte) {
 	}
 }
 
-// Set64 sets the 64 bytes starting at offset to the value of val, left-padded with zeroes to
-// 64 bytes.
+// Set64 sets one VM word starting at offset to the value of val, left-padded with zeroes.
 func (m *Memory) Set64(offset uint64, val *uint512.Int) {
 	// length of store may never be less than offset + size.
 	// The store should be resized PRIOR to setting the memory
-	if offset+64 > uint64(len(m.store)) {
+	if offset+WordBytes > uint64(len(m.store)) {
 		panic("invalid memory: store empty")
 	}
 	// Fill in relevant bits

--- a/core/vm/memory_table.go
+++ b/core/vm/memory_table.go
@@ -37,7 +37,7 @@ func memoryExtCodeCopy(stack *Stack) (uint64, bool) {
 }
 
 func memoryMLoad(stack *Stack) (uint64, bool) {
-	return calcMemSize64WithUint(stack.Back(0), 64)
+	return calcMemSize64WithUint(stack.Back(0), uint64(WordBytes))
 }
 
 func memoryMStore8(stack *Stack) (uint64, bool) {
@@ -45,7 +45,7 @@ func memoryMStore8(stack *Stack) (uint64, bool) {
 }
 
 func memoryMStore(stack *Stack) (uint64, bool) {
-	return calcMemSize64WithUint(stack.Back(0), 64)
+	return calcMemSize64WithUint(stack.Back(0), uint64(WordBytes))
 }
 
 func memoryCreate(stack *Stack) (uint64, bool) {


### PR DESCRIPTION
## Summary

Add shared word-size constants for both `uint512.Int` and the VM word width.

This keeps the integer package constants generic to `uint512.Int`, while `core/vm` exposes VM-owned `WordBits` and `WordBytes` constants for runtime/protocol word-size logic.

This PR also replaces local `512` / `64` literals in direct VM word operations, including shift bounds, memory sizing, `CALLDATALOAD`, `MLOAD`, `MSTORE`, and init-code word sizing.

This is a focused extraction from #49. Follow-up PRs can handle the remaining ABI, RPC, hexutil, signer/fourbyte, and memory expansion boundary changes separately.

## Tests

- `go test ./...`
- `git diff --check`