### PR TITLE
Fix VM memory expansion bound

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -21,18 +21,20 @@ import (
 	"github.com/theQRL/go-qrl/params"
 )
 
+const (
+	maxMemoryExpansionWords = uint64(0xffffffff)
+	maxMemoryExpansionBytes = maxMemoryExpansionWords * uint64(WordBytes)
+)
+
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
 // only for the memory region that is expanded, not the total memory.
 func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 	if newMemSize == 0 {
 		return 0, nil
 	}
-	// The maximum that will fit in a uint64 is max_word_count - 1. Anything above
-	// that will result in an overflow. Additionally, a newMemSize which results in
-	// a newMemSizeWords larger than 0xFFFFFFFF will cause the square operation to
-	// overflow. The constant 0x1FFFFFFFE0 is the highest number that can be used
-	// without overflowing the gas calculation.
-	if newMemSize > 0x1FFFFFFFE0 {
+	// The memory gas formula squares the word count in uint64 arithmetic. The
+	// largest safe word count is 0xffffffff; one more word would wrap the square.
+	if newMemSize > maxMemoryExpansionBytes {
 		return 0, ErrGasUintOverflow
 	}
 	newMemSizeWords := toWordSize(newMemSize)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -22,8 +22,12 @@ import (
 )
 
 const (
-	maxMemoryExpansionWords = uint64(0xffffffff)
-	maxMemoryExpansionBytes = maxMemoryExpansionWords * uint64(WordBytes)
+	// memoryGasCost computes square := words * words using uint64 arithmetic.
+	// The largest word count whose square still fits in uint64 is 2^32-1
+	// (0xffffffff); 2^32 squared is 2^64 and would wrap. Convert that safe word
+	// count through WordBytes so the byte limit follows the VM word width.
+	maxMemoryExpansionWordCount = uint64(0xffffffff)
+	maxMemoryExpansionBytes     = maxMemoryExpansionWordCount * uint64(WordBytes)
 )
 
 // memoryGasCost calculates the quadratic gas for memory expansion. It does so
@@ -32,8 +36,7 @@ func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 	if newMemSize == 0 {
 		return 0, nil
 	}
-	// The memory gas formula squares the word count in uint64 arithmetic. The
-	// largest safe word count is 0xffffffff; one more word would wrap the square.
+	// Reject memory sizes that would round up past the safe word-count limit.
 	if newMemSize > maxMemoryExpansionBytes {
 		return 0, ErrGasUintOverflow
 	}

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -36,12 +36,9 @@ func TestMemoryGasCost(t *testing.T) {
 		cost     uint64
 		overflow bool
 	}{
-		// The overflow threshold is still 0x1FFFFFFFE0, but the gas cost at
-		// that boundary drops by 4x relative to the 32-byte-word chain:
-		// doubling the word width quarters the squared word count that
-		// drives the quadratic term.
-		{0x1fffffffe0, 9007205697191936, false},
-		{0x1fffffffe1, 0, true},
+		// One more byte would round up to a word count whose square overflows uint64.
+		{maxMemoryExpansionBytes, 36028809887088637, false},
+		{maxMemoryExpansionBytes + 1, 0, true},
 	}
 	for i, tt := range tests {
 		v, err := memoryGasCost(&Memory{}, tt.size)


### PR DESCRIPTION
## Summary

- Derive the VM memory expansion byte limit from the safe word-count limit and `WordBytes`.
- Update the boundary test for the last safe byte and first overflowing byte.

## Rationale

`memoryGasCost` squares the expanded memory word count in `uint64` arithmetic. The largest word count whose square still fits is `0xffffffff`; one more word would square to `2^64` and wrap.

The previous literal `0x1fffffffe0` was `0xffffffff * 32`, which matched a 32-byte word size. QRL VM words are 64 bytes, so the safe byte limit should be `0xffffffff * WordBytes` instead.

This is a focused extraction from #49.

## Tests

- `go test -count=1 ./core/vm -run TestMemoryGasCost`
- `go test ./core/vm`
- `git diff --check cyyber/main...HEAD`
