### PR TITLE
[REFACTOR] Rename withdrawal credentials to withdrawal recipient and use constants

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -79,6 +79,17 @@ func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uin
 
 type depositroot struct{}
 
+const (
+	depositPublicKeyLength           = 2592
+	depositWithdrawalRecipientLength = 64
+	depositAmountLength              = 8
+	depositSignatureLength           = 4627
+	depositPublicKeyOffset           = 0
+	depositWithdrawalRecipientOffset = depositPublicKeyOffset + depositPublicKeyLength
+	depositAmountOffset              = depositWithdrawalRecipientOffset + depositWithdrawalRecipientLength
+	depositSignatureOffset           = depositAmountOffset + depositAmountLength
+)
+
 // TODO(now.youtrack.cloud/issue/TGZ-5)
 func (c *depositroot) RequiredGas(input []byte) uint64 {
 	// NOTE(rgeraldes): number of sha256 ops below does not include the number of zero
@@ -89,10 +100,10 @@ func (c *depositroot) RequiredGas(input []byte) uint64 {
 
 func (c *depositroot) Run(input []byte) ([]byte, error) {
 	var (
-		pkBytes             = getData(input, 0, 2592)    // 2592 bytes
-		withdrawalRecipient = getData(input, 2592, 64)   // 64 bytes
-		amountBytes         = getData(input, 2656, 8)    // 8 bytes
-		sigBytes            = getData(input, 2664, 4627) // 4627 bytes
+		pkBytes                  = getData(input, depositPublicKeyOffset, depositPublicKeyLength)
+		withdrawalRecipientBytes = getData(input, depositWithdrawalRecipientOffset, depositWithdrawalRecipientLength)
+		amountBytes              = getData(input, depositAmountOffset, depositAmountLength)
+		sigBytes                 = getData(input, depositSignatureOffset, depositSignatureLength)
 	)
 
 	var amountUint uint64
@@ -104,7 +115,7 @@ func (c *depositroot) Run(input []byte) ([]byte, error) {
 
 	data := &depositdata{
 		PublicKey:           pkBytes,
-		WithdrawalRecipient: withdrawalRecipient,
+		WithdrawalRecipient: withdrawalRecipientBytes,
 		Amount:              amountUint,
 		Signature:           sigBytes,
 	}
@@ -133,15 +144,15 @@ func (d *depositdata) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	indx := hh.Index()
 
 	// Field (0) 'Pubkey'
-	if size := len(d.PublicKey); size != 2592 {
-		err = ssz.ErrBytesLengthFn("--.Pubkey", size, 2592)
+	if size := len(d.PublicKey); size != depositPublicKeyLength {
+		err = ssz.ErrBytesLengthFn("--.Pubkey", size, depositPublicKeyLength)
 		return
 	}
 	hh.PutBytes(d.PublicKey)
 
 	// Field (1) 'WithdrawalRecipient'
-	if size := len(d.WithdrawalRecipient); size != 64 {
-		err = ssz.ErrBytesLengthFn("--.WithdrawalRecipient", size, 64)
+	if size := len(d.WithdrawalRecipient); size != depositWithdrawalRecipientLength {
+		err = ssz.ErrBytesLengthFn("--.WithdrawalRecipient", size, depositWithdrawalRecipientLength)
 		return
 	}
 	hh.PutBytes(d.WithdrawalRecipient)
@@ -150,8 +161,8 @@ func (d *depositdata) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	hh.PutUint64(d.Amount)
 
 	// Field (3) 'Signature'
-	if size := len(d.Signature); size != 4627 {
-		err = ssz.ErrBytesLengthFn("--.Signature", size, 4627)
+	if size := len(d.Signature); size != depositSignatureLength {
+		err = ssz.ErrBytesLengthFn("--.Signature", size, depositSignatureLength)
 		return
 	}
 	hh.PutBytes(d.Signature)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -89,10 +89,10 @@ func (c *depositroot) RequiredGas(input []byte) uint64 {
 
 func (c *depositroot) Run(input []byte) ([]byte, error) {
 	var (
-		pkBytes     = getData(input, 0, 2592)    // 2592 bytes
-		credsBytes  = getData(input, 2592, 64)   // 64 bytes
-		amountBytes = getData(input, 2656, 8)    // 8 bytes
-		sigBytes    = getData(input, 2664, 4627) // 4627 bytes
+		pkBytes             = getData(input, 0, 2592)    // 2592 bytes
+		withdrawalRecipient = getData(input, 2592, 64)   // 64 bytes
+		amountBytes         = getData(input, 2656, 8)    // 8 bytes
+		sigBytes            = getData(input, 2664, 4627) // 4627 bytes
 	)
 
 	var amountUint uint64
@@ -103,10 +103,10 @@ func (c *depositroot) Run(input []byte) ([]byte, error) {
 	}
 
 	data := &depositdata{
-		PublicKey:             pkBytes,
-		WithdrawalCredentials: credsBytes,
-		Amount:                amountUint,
-		Signature:             sigBytes,
+		PublicKey:           pkBytes,
+		WithdrawalRecipient: withdrawalRecipient,
+		Amount:              amountUint,
+		Signature:           sigBytes,
 	}
 	h, err := data.HashTreeRoot()
 	if err != nil {
@@ -117,10 +117,10 @@ func (c *depositroot) Run(input []byte) ([]byte, error) {
 }
 
 type depositdata struct {
-	PublicKey             []byte
-	WithdrawalCredentials []byte
-	Amount                uint64
-	Signature             []byte
+	PublicKey           []byte
+	WithdrawalRecipient []byte
+	Amount              uint64
+	Signature           []byte
 }
 
 // HashTreeRoot ssz hashes the Deposit_Data object
@@ -139,12 +139,12 @@ func (d *depositdata) HashTreeRootWith(hh *ssz.Hasher) (err error) {
 	}
 	hh.PutBytes(d.PublicKey)
 
-	// Field (1) 'WithdrawalCredentials'
-	if size := len(d.WithdrawalCredentials); size != 64 {
-		err = ssz.ErrBytesLengthFn("--.WithdrawalCredentials", size, 64)
+	// Field (1) 'WithdrawalRecipient'
+	if size := len(d.WithdrawalRecipient); size != 64 {
+		err = ssz.ErrBytesLengthFn("--.WithdrawalRecipient", size, 64)
 		return
 	}
-	hh.PutBytes(d.WithdrawalCredentials)
+	hh.PutBytes(d.WithdrawalRecipient)
 
 	// Field (2) 'Amount'
 	hh.PutUint64(d.Amount)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -27,6 +27,7 @@ import (
 	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/theQRL/go-qrl/common"
 	"github.com/theQRL/go-qrl/common/math"
+	"github.com/theQRL/go-qrl/crypto/pqcrypto"
 	"github.com/theQRL/go-qrl/params"
 )
 
@@ -80,10 +81,10 @@ func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uin
 type depositroot struct{}
 
 const (
-	depositPublicKeyLength           = 2592
-	depositWithdrawalRecipientLength = 64
+	depositPublicKeyLength           = pqcrypto.MLDSA87PublicKeyLength
+	depositWithdrawalRecipientLength = common.AddressLength
 	depositAmountLength              = 8
-	depositSignatureLength           = 4627
+	depositSignatureLength           = pqcrypto.MLDSA87SignatureLength
 	depositPublicKeyOffset           = 0
 	depositWithdrawalRecipientOffset = depositPublicKeyOffset + depositPublicKeyLength
 	depositAmountOffset              = depositWithdrawalRecipientOffset + depositWithdrawalRecipientLength


### PR DESCRIPTION
## Summary

- Rename the deposit root precompile's internal deposit-data field from withdrawal credentials to withdrawal recipient.
- Reuse the existing ML-DSA-87 public key/signature and address length constants for deposit data field sizes while keeping local offsets for slicing.

## Rationale

In QRL this 64-byte value is the address that receives withdrawals, not an Ethereum-style withdrawal credentials container. The credentials prefix logic was removed from withdrawal credentials, so the deposit data now carries only the withdrawal recipient without any credentials prefix. The new name matches the current protocol meaning while preserving the same SSZ field order and byte width.

## Tests

- `go test ./...` (passes)
- `git diff --check` (passes)