### PR TITLE
[FIX] Use StorageValue64 for mkalloc storage values

### DIFF
--- a/core/mkalloc.go
+++ b/core/mkalloc.go
@@ -51,7 +51,7 @@ type allocItemMisc struct {
 
 type allocItemStorageItem struct {
 	Key common.Hash
-	Val common.Hash
+	Val common.StorageValue64
 }
 
 func makelist(g *core.Genesis) []allocItem {


### PR DESCRIPTION
## Summary

- Change `core/mkalloc.go` so generated genesis storage items use `common.StorageValue64` values instead of `common.Hash`.
- Leave the existing generated `core/genesis_alloc.go` data unchanged in this PR.

## Rationale

`core.GenesisAccount.Storage` already stores values as `map[common.Hash]common.StorageValue64`, but the `mkalloc` generator still modeled storage item values as `common.Hash`. That type is incompatible with the current `StorageValue64` genesis storage model and would not correctly represent full-width generated storage values.

This PR only fixes the generator type. It intentionally does not regenerate `core/genesis_alloc.go` or change any existing values in `genesis_alloc`; any generated-data refresh can be handled separately if needed.

## Tests

- `go run core/mkalloc.go cmd/gqrl/testdata/genesis.json >/tmp/go-qrl-mkalloc-genesis-alloc.out`
- Temporary 64-byte storage genesis: `go run core/mkalloc.go /tmp/go-qrl-mkalloc-storage64-genesis.json >/tmp/go-qrl-mkalloc-storage64.out`; decoded generated RLP confirmed `decoded 1 alloc item, 1 slot, storage value length 64 bytes`
- `go test -count=1 ./core`
- `go test -count=1 ./core/...`
- `git diff --check`
