### PR TITLE
[FIX] Refresh VM64 state and snap storage fixtures

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -333,7 +333,7 @@ func makeHeaderChainWithGenesis(genesis *Genesis, n int, engine consensus.Engine
 // makeBlockChain creates a deterministic chain of blocks rooted at parent.
 func makeBlockChain(chainConfig *params.ChainConfig, parent *types.Block, n int, engine consensus.Engine, db qrldb.Database, seed int) []*types.Block {
 	blocks, _ := GenerateChain(chainConfig, parent, engine, db, n, func(i int, b *BlockGen) {
-		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
+		b.SetCoinbase(common.Address{0: byte(seed), common.AddressLength - 1: byte(i)})
 	})
 	return blocks
 }
@@ -341,7 +341,7 @@ func makeBlockChain(chainConfig *params.ChainConfig, parent *types.Block, n int,
 // makeBlockChain creates a deterministic chain of blocks from genesis
 func makeBlockChainWithGenesis(genesis *Genesis, n int, engine consensus.Engine, seed int) (qrldb.Database, []*types.Block) {
 	db, blocks, _ := GenerateChainWithGenesis(genesis, engine, n, func(i int, b *BlockGen) {
-		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
+		b.SetCoinbase(common.Address{0: byte(seed), common.AddressLength - 1: byte(i)})
 	})
 	return db, blocks
 }

--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -44,12 +44,12 @@ var (
 	aggregatorMemoryLimit = uint64(4 * 1024 * 1024)
 
 	// aggregatorItemLimit is an approximate number of items that will end up
-	// in the agregator layer before it's flushed out to disk. A plain account
-	// weighs around 14B (+hash), a storage slot 32B (+hash), a deleted slot
-	// 0B (+hash). Slots are mostly set/unset in lockstep, so that average at
-	// 16B (+hash). All in all, the average entry seems to be 15+32=47B. Use a
-	// smaller number to be on the safe side.
-	aggregatorItemLimit = aggregatorMemoryLimit / 42
+	// in the aggregator layer before it's flushed out to disk. A plain account
+	// weighs around 14B (+hash), a VM64 storage slot 64B (+hash), a deleted
+	// slot 0B (+hash). Slots are mostly set/unset in lockstep, so that average
+	// is around 32B (+hash). All in all, the average entry seems to be
+	// 31+32=63B. Use 64B as the rounded divisor.
+	aggregatorItemLimit = aggregatorMemoryLimit / 64
 
 	// bloomTargetError is the target false positive rate when the aggregator
 	// layer is at its fullest. The actual value will probably move around up

--- a/core/state/snapshot/difflayer_test.go
+++ b/core/state/snapshot/difflayer_test.go
@@ -70,7 +70,7 @@ func TestMergeBasics(t *testing.T) {
 		}
 		if rand.Intn(2) == 0 {
 			accStorage := make(map[common.Hash][]byte)
-			value := make([]byte, 32)
+			value := make([]byte, common.StorageValue64Length)
 			crand.Read(value)
 			accStorage[randomHash()] = value
 			storage[h] = accStorage
@@ -290,7 +290,7 @@ func BenchmarkSearchSlot(b *testing.B) {
 
 		accStorage := make(map[common.Hash][]byte)
 		for range 5 {
-			value := make([]byte, 32)
+			value := make([]byte, common.StorageValue64Length)
 			crand.Read(value)
 			accStorage[randomHash()] = value
 			storage[accountKey] = accStorage
@@ -325,7 +325,7 @@ func BenchmarkFlatten(b *testing.B) {
 
 			accStorage := make(map[common.Hash][]byte)
 			for range 20 {
-				value := make([]byte, 32)
+				value := make([]byte, common.StorageValue64Length)
 				crand.Read(value)
 				accStorage[randomHash()] = value
 			}
@@ -372,7 +372,7 @@ func BenchmarkJournal(b *testing.B) {
 
 			accStorage := make(map[common.Hash][]byte)
 			for range 200 {
-				value := make([]byte, 32)
+				value := make([]byte, common.StorageValue64Length)
 				crand.Read(value)
 				accStorage[randomHash()] = value
 			}

--- a/core/state/snapshot/iterator_test.go
+++ b/core/state/snapshot/iterator_test.go
@@ -47,7 +47,7 @@ func TestAccountIteratorBasics(t *testing.T) {
 		}
 		if rand.Intn(2) == 0 {
 			accStorage := make(map[common.Hash][]byte)
-			value := make([]byte, 32)
+			value := make([]byte, common.StorageValue64Length)
 			crand.Read(value)
 			accStorage[randomHash()] = value
 			storage[h] = accStorage
@@ -76,7 +76,7 @@ func TestStorageIteratorBasics(t *testing.T) {
 		accounts[h] = randomAccount()
 
 		accStorage := make(map[common.Hash][]byte)
-		value := make([]byte, 32)
+		value := make([]byte, common.StorageValue64Length)
 
 		var nilstorage int
 		for range 100 {

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -41,6 +41,14 @@ func randomHash() common.Hash {
 	return hash
 }
 
+func randomStorageValue() []byte {
+	value := make([]byte, common.StorageValue64Length)
+	if n, err := crand.Read(value); n != common.StorageValue64Length || err != nil {
+		panic(err)
+	}
+	return value
+}
+
 // randomAccount generates a random account and returns it RLP encoded.
 func randomAccount() []byte {
 	a := &types.StateAccount{
@@ -73,7 +81,7 @@ func randomStorageSet(accounts []string, hashes [][]string, nilStorage [][]strin
 		if index < len(hashes) {
 			hashes := hashes[index]
 			for _, hash := range hashes {
-				storages[common.HexToHash(account)][common.HexToHash(hash)] = randomHash().Bytes()
+				storages[common.HexToHash(account)][common.HexToHash(hash)] = randomStorageValue()
 			}
 		}
 		if index < len(nilStorage) {

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -40,6 +40,15 @@ type testAccount struct {
 	code    []byte
 }
 
+func testStorageValue(seed byte) common.StorageValue64 {
+	var value common.StorageValue64
+	for i := range value {
+		value[i] = seed + byte(i*17) + 1
+	}
+	value[0] |= 0x80
+	return value
+}
+
 // makeTestState create a sample test state to test node-wise reconstruction.
 func makeTestState(scheme string) (qrldb.Database, Database, *trie.Database, common.Hash, []*testAccount) {
 	// Create an empty state
@@ -73,7 +82,7 @@ func makeTestState(scheme string) (qrldb.Database, Database, *trie.Database, com
 		if i%5 == 0 {
 			for j := range byte(5) {
 				hash := crypto.Keccak256Hash([]byte{i, i, i, i, i, j, j})
-				obj.SetState(hash, common.BytesToStorageValue64(hash.Bytes()))
+				obj.SetState(hash, testStorageValue(i+j))
 			}
 		}
 		accounts = append(accounts, acc)

--- a/qrl/protocols/snap/handler_fuzzing_test.go
+++ b/qrl/protocols/snap/handler_fuzzing_test.go
@@ -90,7 +90,7 @@ var trieRoot common.Hash
 
 func getChain() *core.BlockChain {
 	ga := make(core.GenesisAlloc, 1000)
-	var a = make([]byte, 20)
+	var a = make([]byte, common.AddressLength)
 	var mkStorage = func(k, v int) (common.Hash, common.StorageValue64) {
 		var kB = make([]byte, 32)
 		var vB = make([]byte, 64)

--- a/qrl/protocols/snap/sync.go
+++ b/qrl/protocols/snap/sync.go
@@ -56,6 +56,10 @@ const (
 	// Bytecode and trienode are limited more explicitly by the caps below.
 	maxRequestSize = 512 * 1024
 
+	// storageRangeEntrySize is the pessimistic size of one storage range result:
+	// a 32-byte storage key and an RLP-encoded full-width 64-byte storage value.
+	storageRangeEntrySize = common.HashLength + common.StorageValue64Length + 2
+
 	// maxCodeRequestCount is the maximum number of bytecode blobs to request in a
 	// single query. If this number is too low, we're not filling responses fully
 	// and waste round trip times. If it's too high, we're capping responses and
@@ -1972,13 +1976,13 @@ func (s *Syncer) processStorageResponse(res *storageResponse) {
 						lastKey = keys[len(keys)-1]
 					}
 					// If the number of slots remaining is low, decrease the
-					// number of chunks. Somewhere on the order of 10-15K slots
-					// fit into a packet of 500KB. A key/slot pair is maximum 64
-					// bytes, so pessimistically maxRequestSize/64 = 8K.
+					// number of chunks. Somewhere on the order of 5K slots fit
+					// into a packet of 500KB. A key/value pair is maximum 98
+					// bytes, so pessimistically maxRequestSize/98 = 5K.
 					//
 					// Chunk so that at least 2 packets are needed to fill a task.
 					if estimate, err := estimateRemainingSlots(len(keys), lastKey); err == nil {
-						if n := estimate / (2 * (maxRequestSize / 64)); n+1 < chunks {
+						if n := estimate / (2 * (maxRequestSize / storageRangeEntrySize)); n+1 < chunks {
 							chunks = n + 1
 						}
 						log.Debug("Chunked large contract", "initiators", len(keys), "tail", lastKey, "remaining", estimate, "chunks", chunks)
@@ -3002,7 +3006,7 @@ func estimateRemainingSlots(hashes int, last common.Hash) (uint64, error) {
 	space := new(big.Int).Mul(math.MaxBig256, big.NewInt(int64(hashes)))
 	space.Div(space, last.Big())
 	if !space.IsUint64() {
-		// Gigantic address space probably due to too few or malicious slots
+		// Gigantic hash space probably due to too few or malicious slots
 		return 0, errors.New("too few slots for estimation")
 	}
 	return space.Uint64() - uint64(hashes), nil

--- a/qrl/protocols/snap/sync_test.go
+++ b/qrl/protocols/snap/sync_test.go
@@ -1727,9 +1727,9 @@ func makeStorageTrieWithSeed(owner common.Hash, n, seed uint64, db *trie.Databas
 	trie, _ := trie.New(trie.StorageTrieID(types.EmptyRootHash, owner, types.EmptyRootHash), db)
 	var entries []*kv
 	for i := uint64(1); i <= n; i++ {
-		// store 'x' at slot 'x'
-		slotValue := key32(i + seed)
-		rlpSlotValue, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(slotValue[:]))
+		// Store a full-width VM64 value at slot 'x'.
+		slotValue := storageValue64(i + seed)
+		rlpSlotValue, _ := rlpStorageValue(slotValue)
 
 		slotKey := key32(i)
 		key := crypto.Keccak256Hash(slotKey[:])
@@ -1741,6 +1741,19 @@ func makeStorageTrieWithSeed(owner common.Hash, n, seed uint64, db *trie.Databas
 	slices.SortFunc(entries, (*kv).cmp)
 	root, nodes, _ := trie.Commit(false)
 	return root, nodes, entries
+}
+
+func storageValue64(seed uint64) []byte {
+	value := make([]byte, common.StorageValue64Length)
+	for i := range value {
+		value[i] = byte(seed + uint64(i*17) + 1)
+	}
+	value[0] |= 0x80
+	return value
+}
+
+func rlpStorageValue(value []byte) ([]byte, error) {
+	return rlp.EncodeToBytes(common.TrimLeftZeroes(value))
 }
 
 // makeBoundaryStorageTrie constructs a storage trie. Instead of filling
@@ -1771,7 +1784,8 @@ func makeBoundaryStorageTrie(owner common.Hash, n int, db *trie.Database) (commo
 	// Fill boundary slots
 	for i := 0; i < len(boundaries); i++ {
 		key := boundaries[i]
-		val := []byte{0xde, 0xad, 0xbe, 0xef}
+		slotValue := storageValue64(uint64(i) + 0xdead)
+		val, _ := rlpStorageValue(slotValue)
 
 		elem := &kv{key[:], val}
 		trie.MustUpdate(elem.k, elem.v)
@@ -1782,8 +1796,8 @@ func makeBoundaryStorageTrie(owner common.Hash, n int, db *trie.Database) (commo
 		slotKey := key32(i)
 		key := crypto.Keccak256Hash(slotKey[:])
 
-		slotValue := key32(i)
-		rlpSlotValue, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(slotValue[:]))
+		slotValue := storageValue64(i)
+		rlpSlotValue, _ := rlpStorageValue(slotValue)
 
 		elem := &kv{key[:], rlpSlotValue}
 		trie.MustUpdate(elem.k, elem.v)
@@ -1814,7 +1828,9 @@ func makeUnevenStorageTrie(owner common.Hash, slots int, db *trie.Database) (com
 		}
 		for j := 0; j < slots/3; j++ {
 			key := append([]byte{byte(n)}, testutil.RandBytes(31)...)
-			val, _ := rlp.EncodeToBytes(testutil.RandBytes(32))
+			slotValue := testutil.RandBytes(common.StorageValue64Length)
+			slotValue[0] |= 0x80
+			val, _ := rlpStorageValue(slotValue)
 
 			elem := &kv{key, val}
 			tr.MustUpdate(elem.k, elem.v)

--- a/tests/fuzzers/rangeproof/rangeproof-fuzzer.go
+++ b/tests/fuzzers/rangeproof/rangeproof-fuzzer.go
@@ -39,6 +39,8 @@ type fuzzer struct {
 	exhausted bool
 }
 
+var valueSizes = [...]int{1, 20, common.StorageValue64Length, common.StorageValue64Length + 2}
+
 func (f *fuzzer) randBytes(n int) []byte {
 	r := make([]byte, n)
 	if _, err := f.input.Read(r); err != nil {
@@ -55,18 +57,34 @@ func (f *fuzzer) readInt() uint64 {
 	return x
 }
 
+func (f *fuzzer) randValue() []byte {
+	size := valueSizes[f.readInt()%uint64(len(valueSizes))]
+	return f.randBytes(size)
+}
+
+func seededValue(seed byte, size int) []byte {
+	value := make([]byte, size)
+	for i := range value {
+		value[i] = seed + byte(i)
+	}
+	return value
+}
+
 func (f *fuzzer) randomTrie(n int) (*trie.Trie, map[string]*kv) {
 	trie := trie.NewEmpty(trie.NewDatabase(rawdb.NewMemoryDatabase(), nil))
 	vals := make(map[string]*kv)
 	size := f.readInt()
 	// Fill it with some fluff
 	for i := byte(0); i < byte(size); i++ {
-		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}
-		value2 := &kv{common.LeftPadBytes([]byte{i + 10}, 32), []byte{i}, false}
+		value := &kv{common.LeftPadBytes([]byte{i}, 32), seededValue(i+1, 1), false}
+		value2 := &kv{common.LeftPadBytes([]byte{i + 10}, 32), seededValue(i+1, common.StorageValue64Length), false}
+		value3 := &kv{common.LeftPadBytes([]byte{i + 20}, 32), seededValue(i+1, common.StorageValue64Length+2), false}
 		trie.MustUpdate(value.k, value.v)
 		trie.MustUpdate(value2.k, value2.v)
+		trie.MustUpdate(value3.k, value3.v)
 		vals[string(value.k)] = value
 		vals[string(value2.k)] = value2
+		vals[string(value3.k)] = value3
 	}
 	if f.exhausted {
 		return nil, nil
@@ -74,7 +92,7 @@ func (f *fuzzer) randomTrie(n int) (*trie.Trie, map[string]*kv) {
 	// And now fill with some random
 	for range n {
 		k := f.randBytes(32)
-		v := f.randBytes(20)
+		v := f.randValue()
 		value := &kv{k, v, false}
 		trie.MustUpdate(k, v)
 		vals[string(k)] = value
@@ -136,7 +154,7 @@ func (f *fuzzer) fuzz() int {
 			keys[index%len(keys)] = f.randBytes(32) // In theory it can't be same
 		case 1:
 			// Modified val
-			vals[index%len(vals)] = f.randBytes(20) // In theory it can't be same
+			vals[index%len(vals)] = f.randValue() // In theory it can't be same
 		case 2:
 			// Gapped entry slice
 			index = index % len(keys)

--- a/trie/triedb/pathdb/database_test.go
+++ b/trie/triedb/pathdb/database_test.go
@@ -142,7 +142,7 @@ func (t *tester) generateStorage(ctx *genctx, addr common.Address) common.Hash {
 		origin   = make(map[common.Hash][]byte)
 	)
 	for range 10 {
-		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testutil.RandBytes(32)))
+		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testutil.RandBytes(common.StorageValue64Length)))
 		hash := testutil.RandomHash()
 
 		storage[hash] = v
@@ -171,7 +171,7 @@ func (t *tester) mutateStorage(ctx *genctx, addr common.Address, root common.Has
 		}
 	}
 	for range 3 {
-		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testutil.RandBytes(32)))
+		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testutil.RandBytes(common.StorageValue64Length)))
 		hash := testutil.RandomHash()
 
 		storage[hash] = v

--- a/trie/triedb/pathdb/history.go
+++ b/trie/triedb/pathdb/history.go
@@ -76,7 +76,7 @@ const (
 // # metadata
 //  This object contains a few meta fields, such as the associated state root,
 //  block number, version tag and so on. This object may contain an extra
-//  accountHash list which means the storage changes belong to these accounts
+//  account address list which means the storage changes belong to these accounts
 //  are not complete due to large contract destruction. The incomplete history
 //  can not be used for rollback and serving archive state request.
 //
@@ -170,7 +170,7 @@ func (i *accountIndex) decode(blob []byte) {
 // slotIndex describes the metadata belonging to a storage slot.
 type slotIndex struct {
 	hash   common.Hash // The hash of slot key
-	length uint8       // The length of storage slot, up to 32 bytes defined in protocol
+	length uint8       // The length of serialized storage slot payload
 	offset uint32      // The offset of item in storage slot data table
 }
 
@@ -246,9 +246,9 @@ func (m *meta) decode(blob []byte) error {
 // in order to control the storage size.
 type history struct {
 	meta        *meta                                     // Meta data of history
-	accounts    map[common.Address][]byte                 // Account data keyed by its address hash
-	accountList []common.Address                          // Sorted account hash list
-	storages    map[common.Address]map[common.Hash][]byte // Storage data keyed by its address hash and slot hash
+	accounts    map[common.Address][]byte                 // Account data keyed by its address
+	accountList []common.Address                          // Sorted account address list
+	storages    map[common.Address]map[common.Hash][]byte // Storage data keyed by its address and slot hash
 	storageList map[common.Address][]common.Hash          // Sorted slot hash list
 }
 

--- a/trie/triedb/pathdb/history_test.go
+++ b/trie/triedb/pathdb/history_test.go
@@ -41,7 +41,7 @@ func randomStateSet(n int) *triestate.Set {
 		addr := testutil.RandomAddress()
 		storages[addr] = make(map[common.Hash][]byte)
 		for range 3 {
-			v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testutil.RandBytes(32)))
+			v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(testutil.RandBytes(common.StorageValue64Length)))
 			storages[addr][testutil.RandomHash()] = v
 		}
 		account := generateAccount(types.EmptyRootHash)
@@ -99,6 +99,48 @@ func TestEncodeDecodeHistory(t *testing.T) {
 	}
 	if !compareStorageList(dec.storageList, obj.storageList) {
 		t.Fatal("storage list is mismatched")
+	}
+}
+
+func TestHistoryFullWidthStoragePayload(t *testing.T) {
+	var (
+		addr     = common.BytesToAddress(bytes.Repeat([]byte{0x11}, common.AddressLength))
+		slot     = common.HexToHash("0x01")
+		value    = bytes.Repeat([]byte{0xff}, common.StorageValue64Length)
+		encoded  []byte
+		decoded  history
+		storages = map[common.Address]map[common.Hash][]byte{
+			addr: {},
+		}
+		accounts = map[common.Address][]byte{
+			addr: types.SlimAccountRLP(generateAccount(types.EmptyRootHash)),
+		}
+	)
+	var err error
+	encoded, err = rlp.EncodeToBytes(common.TrimLeftZeroes(value))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := common.StorageValue64Length + 2; len(encoded) != want {
+		t.Fatalf("encoded full-width storage payload length mismatch: have %d, want %d", len(encoded), want)
+	}
+	storages[addr][slot] = encoded
+
+	obj := newHistory(testutil.RandomHash(), types.EmptyRootHash, 1, triestate.New(accounts, storages, nil))
+	accountData, storageData, accountIndexes, storageIndexes := obj.encode()
+	if len(storageData) != len(encoded) {
+		t.Fatalf("storage data length mismatch: have %d, want %d", len(storageData), len(encoded))
+	}
+	var index slotIndex
+	index.decode(storageIndexes)
+	if int(index.length) != len(encoded) {
+		t.Fatalf("slot index length mismatch: have %d, want %d", index.length, len(encoded))
+	}
+	if err := decoded.decode(accountData, storageData, accountIndexes, storageIndexes); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if have := decoded.storages[addr][slot]; !bytes.Equal(have, encoded) {
+		t.Fatalf("decoded storage payload mismatch:\nhave %x\nwant %x", have, encoded)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Refresh state, snapshot, and pathdb storage fixtures so tests exercise full 64-byte `StorageValue64` values instead of mostly 32-byte hash-shaped values.
- Update snap storage range sizing to account for full-width storage values encoded as RLP payloads.
- Update snap and chain fixture helpers to use QRL address/storage widths instead of hard-coded legacy sizes.
- Expand the rangeproof fuzzer to include full-width storage value payload sizes.

## Tests

- `go test -count=1 ./core/state ./core/state/snapshot ./trie/triedb/pathdb`
- `go test -count=1 ./qrl/protocols/snap ./tests/fuzzers/rangeproof`
- `go test -run '^$' ./core`
- `git diff --check`
