### PR TITLE
Remove stale Clique comments

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -392,8 +392,8 @@ func NewBlockChain(db qrldb.Database, cacheConfig *CacheConfig, genesis *Genesis
 			}
 		}
 	}
-	// The first thing the node will do is reconstruct the verification data for
-	// the head block. Might as well do it in advance.
+	// Verify the current head once during startup, before normal block
+	// processing starts.
 	bc.engine.VerifyHeader(bc, bc.CurrentHeader())
 
 	// Load any existing snapshot, regenerating it if loading failed

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -393,8 +393,7 @@ func NewBlockChain(db qrldb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		}
 	}
 	// The first thing the node will do is reconstruct the verification data for
-	// the head block (ethash cache or clique voting snapshot). Might as well do
-	// it in advance.
+	// the head block. Might as well do it in advance.
 	bc.engine.VerifyHeader(bc, bc.CurrentHeader())
 
 	// Load any existing snapshot, regenerating it if loading failed
@@ -1577,12 +1576,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			log.Debug("Abort during block processing")
 			break
 		}
-		// If the block is known (in the middle of the chain), it's a special case for
-		// Clique blocks where they can share state among each other, so importing an
-		// older block might complete the state of the subsequent one. In this case,
-		// just skip the block (we already validated it once fully (and crashed), since
-		// its header and body was already in the database). But if the corresponding
-		// snapshot layer is missing, forcibly rerun the execution to build it.
+		// If the block is known (in the middle of the chain), consecutive empty
+		// blocks can share state, so importing an older block might complete the
+		// state of the subsequent one. In this case, just skip the block (we already
+		// validated it once fully (and crashed), since its header and body was
+		// already in the database). But if the corresponding snapshot layer is
+		// missing, forcibly rerun the execution to build it.
 		if bc.skipBlock(err, it) {
 			logger := log.Warn
 			logger("Inserted known block", "number", block.Number(), "hash", block.Hash(),
@@ -1590,13 +1589,13 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 				"root", block.Root())
 
 			// Special case. Commit the empty receipt slice if we meet the known
-			// block in the middle. It can only happen in the clique chain. Whenever
-			// we insert blocks via `insertSideChain`, we only commit `td`, `header`
-			// and `body` if it's non-existent. Since we don't have receipts without
-			// reexecution, so nothing to commit. But if the sidechain will be adopted
-			// as the canonical chain eventually, it needs to be reexecuted for missing
-			// state, but if it's this special case here(skip reexecution) we will lose
-			// the empty receipt entry.
+			// block in the middle. This can happen when consecutive empty blocks
+			// share state. Whenever we insert blocks via `insertSideChain`, we only
+			// commit `td`, `header` and `body` if it's non-existent. Since we don't
+			// have receipts without reexecution, so nothing to commit. But if the
+			// sidechain will be adopted as the canonical chain eventually, it needs
+			// to be reexecuted for missing state, but if it's this special case
+			// here(skip reexecution) we will lose the empty receipt entry.
 			if len(block.Transactions()) == 0 {
 				rawdb.WriteReceipts(bc.db, block.Hash(), block.NumberU64(), nil)
 			} else {
@@ -1608,8 +1607,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			}
 			stats.processed++
 
-			// We can assume that logs are empty here, since the only way for consecutive
-			// Clique blocks to have the same state is if there are no transactions.
+			// We can assume that logs are empty here, since consecutive blocks can
+			// only share state if there are no transactions.
 			lastCanon = block
 			continue
 		}

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -268,13 +268,11 @@ func (p *Pruner) Prune(root common.Hash) error {
 	// is the presence of root can indicate the presence of the
 	// entire trie.
 	if !rawdb.HasLegacyTrieNode(p.db, root) {
-		// The special case is for clique based networks(goerli
-		// and some other private networks), it's possible that two
-		// consecutive blocks will have same root. In this case snapshot
-		// difflayer won't be created. So HEAD-127 may not paired with
-		// head-127 layer. Instead the paired layer is higher than the
-		// bottom-most diff layer. Try to find the bottom-most snapshot
-		// layer with state available.
+		// Consecutive empty blocks can have the same root. In this case a
+		// snapshot difflayer won't be created. So HEAD-127 may not be paired with
+		// head-127 layer. Instead the paired layer is higher than the bottom-most
+		// diff layer. Try to find the bottom-most snapshot layer with state
+		// available.
 		//
 		// Note HEAD and HEAD-1 is ignored. Usually there is the associated
 		// state available, but we don't want to use the topmost state

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -342,8 +342,7 @@ func (t *Tree) Snapshots(root common.Hash, limits int, nodisk bool) []Snapshot {
 // old parent. It is disallowed to insert a disk layer (the origin of all).
 func (t *Tree) Update(blockRoot common.Hash, parentRoot common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte) error {
 	// Reject noop updates to avoid self-loops in the snapshot tree. This is a
-	// special case that can only happen for Clique networks where empty blocks
-	// don't modify the state (0 block subsidy).
+	// special case that can happen when empty blocks don't modify the state.
 	//
 	// Although we could silently ignore this internally, it should be the caller's
 	// responsibility to avoid even attempting to insert such a snapshot.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1175,7 +1175,7 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 	// If snapshotting is enabled, update the snapshot tree with this new version
 	if s.snap != nil {
 		start := time.Now()
-		// Only update if there's a state transition (skip empty Clique blocks)
+		// Only update if there's a state transition.
 		if parent := s.snap.Root(); parent != root {
 			if err := s.snaps.Update(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.accounts, s.storages); err != nil {
 				log.Warn("Failed to update snapshot tree", "from", parent, "to", root, "err", err)

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -237,7 +237,7 @@ func TestRlpDecodeParentHash(t *testing.T) {
 	}
 	// And a maximum one
 	// | Number      | dynamic| *big.Int       | 64 bits               |
-	// | Extra       | dynamic| []byte         | 65+32 byte (clique)   |
+	// | Extra       | dynamic| []byte         | 65+32 byte            |
 	// | BaseFee     | dynamic| *big.Int       | 64 bits               |
 	if rlpData, err := rlp.EncodeToBytes(&Header{
 		ParentHash: want,

--- a/params/network_params.go
+++ b/params/network_params.go
@@ -55,7 +55,7 @@ const (
 
 	// FullImmutabilityThreshold is the number of blocks after which a chain segment is
 	// considered immutable (i.e. soft finality). It is used by the downloader as a
-	// hard limit against deep ancestors, by the blockchain against deep reorgs, by
-	// the freezer as the cutoff threshold and by clique as the snapshot trust limit.
+	// hard limit against deep ancestors, by the blockchain against deep reorgs, and
+	// by the freezer as the cutoff threshold.
 	FullImmutabilityThreshold = 90000
 )


### PR DESCRIPTION
## Summary

- Replace inherited Clique-specific comments with behavior-focused wording around empty blocks, snapshot layers, and immutability thresholds.
- Remove the Clique label from the RLP parent-hash test comment.

## Rationale

Clique consensus is no longer available in this repo. These comments describe generic empty-block or same-root behavior, so the consensus-specific wording is stale and confusing.

## Tests

- `git diff --check`