### PR TITLE
Fix gqrl dump --start and snapshot address parsing

### DIFF
--- a/cmd/gqrl/chaincmd.go
+++ b/cmd/gqrl/chaincmd.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -378,7 +379,7 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, qrl
 	var start common.Hash
 	switch {
 	case startArg == "": // common.Hash
-	case len(startArg) == 2*common.HashLength || len(startArg) == 2+2*common.HashLength:
+	case isHexEncodedHash(startArg):
 		start = common.BytesToHash(common.FromHex(startArg))
 	case common.IsAddress(startArg):
 		addr, err := common.NewAddressFromString(startArg)
@@ -435,4 +436,12 @@ func dump(ctx *cli.Context) error {
 func hashish(x string) bool {
 	_, err := strconv.Atoi(x)
 	return err != nil
+}
+
+func isHexEncodedHash(s string) bool {
+	hashHexLength := 2 * common.HashLength
+	if len(s) == hashHexLength {
+		return true
+	}
+	return len(s) == len("0x")+hashHexLength && (strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X"))
 }

--- a/cmd/gqrl/chaincmd.go
+++ b/cmd/gqrl/chaincmd.go
@@ -376,11 +376,11 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, qrl
 	}
 	startArg := ctx.String(utils.StartKeyFlag.Name)
 	var start common.Hash
-	switch len(startArg) {
-	case 0: // common.Hash
-	case 64, 66:
+	switch {
+	case startArg == "": // common.Hash
+	case len(startArg) == 2*common.HashLength || len(startArg) == 2+2*common.HashLength:
 		start = common.BytesToHash(common.FromHex(startArg))
-	case 41:
+	case common.IsAddress(startArg):
 		addr, err := common.NewAddressFromString(startArg)
 		if err != nil {
 			return nil, nil, common.Hash{}, err
@@ -388,7 +388,7 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, qrl
 		start = crypto.Keccak256Hash(addr.Bytes())
 		log.Info("Converting start-address to hash", "address", addr, "hash", start.Hex())
 	default:
-		return nil, nil, common.Hash{}, fmt.Errorf("invalid start argument: %x. 20 or 32 hex-encoded bytes required", startArg)
+		return nil, nil, common.Hash{}, fmt.Errorf("invalid start argument: %x. Q-prefixed %d-byte address or %d-byte hash required", startArg, common.AddressLength, common.HashLength)
 	}
 	var conf = &state.DumpConfig{
 		SkipCode:          ctx.Bool(utils.ExcludeCodeFlag.Name),

--- a/cmd/gqrl/chaincmd.go
+++ b/cmd/gqrl/chaincmd.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"runtime"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -379,7 +378,7 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, qrl
 	var start common.Hash
 	switch {
 	case startArg == "": // common.Hash
-	case isHexEncodedHash(startArg):
+	case common.IsHexEncodedHash(startArg):
 		start = common.BytesToHash(common.FromHex(startArg))
 	case common.IsAddress(startArg):
 		addr, err := common.NewAddressFromString(startArg)
@@ -436,12 +435,4 @@ func dump(ctx *cli.Context) error {
 func hashish(x string) bool {
 	_, err := strconv.Atoi(x)
 	return err != nil
-}
-
-func isHexEncodedHash(s string) bool {
-	hashHexLength := 2 * common.HashLength
-	if len(s) == hashHexLength {
-		return true
-	}
-	return len(s) == len("0x")+hashHexLength && (strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X"))
 }

--- a/cmd/gqrl/chaincmd.go
+++ b/cmd/gqrl/chaincmd.go
@@ -388,7 +388,7 @@ func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, qrl
 		start = crypto.Keccak256Hash(addr.Bytes())
 		log.Info("Converting start-address to hash", "address", addr, "hash", start.Hex())
 	default:
-		return nil, nil, common.Hash{}, fmt.Errorf("invalid start argument: %x. Q-prefixed %d-byte address or %d-byte hash required", startArg, common.AddressLength, common.HashLength)
+		return nil, nil, common.Hash{}, fmt.Errorf("invalid start argument %q: Q-prefixed %d-byte address or hex-encoded %d-byte hash required", startArg, common.AddressLength, common.HashLength)
 	}
 	var conf = &state.DumpConfig{
 		SkipCode:          ctx.Bool(utils.ExcludeCodeFlag.Name),

--- a/cmd/gqrl/snapshot.go
+++ b/cmd/gqrl/snapshot.go
@@ -618,7 +618,7 @@ func checkAccount(ctx *cli.Context) error {
 			return err
 		}
 		hash = crypto.Keccak256Hash(addr.Bytes())
-	case isHexEncodedHash(arg):
+	case common.IsHexEncodedHash(arg):
 		hash = common.HexToHash(arg)
 	default:
 		return errors.New("malformed address or hash")

--- a/cmd/gqrl/snapshot.go
+++ b/cmd/gqrl/snapshot.go
@@ -611,14 +611,14 @@ func checkAccount(ctx *cli.Context) error {
 		addr common.Address
 		err  error
 	)
-	switch arg := ctx.Args().First(); len(arg) {
-	case 41:
+	switch arg := ctx.Args().First(); {
+	case common.IsAddress(arg):
 		addr, err = common.NewAddressFromString(arg)
 		if err != nil {
 			return err
 		}
 		hash = crypto.Keccak256Hash(addr.Bytes())
-	case 64, 66:
+	case len(arg) == 2*common.HashLength || len(arg) == 2+2*common.HashLength:
 		hash = common.HexToHash(arg)
 	default:
 		return errors.New("malformed address or hash")

--- a/cmd/gqrl/snapshot.go
+++ b/cmd/gqrl/snapshot.go
@@ -618,7 +618,7 @@ func checkAccount(ctx *cli.Context) error {
 			return err
 		}
 		hash = crypto.Keccak256Hash(addr.Bytes())
-	case len(arg) == 2*common.HashLength || len(arg) == 2+2*common.HashLength:
+	case isHexEncodedHash(arg):
 		hash = common.HexToHash(arg)
 	default:
 		return errors.New("malformed address or hash")

--- a/common/types.go
+++ b/common/types.go
@@ -447,6 +447,15 @@ func IsAddress(s string) bool {
 	return len(s) == 2*AddressLength && isHex(s)
 }
 
+// IsHexEncodedHash verifies whether a string can represent a valid hex-encoded
+// 32-byte hash, with or without 0x prefix.
+func IsHexEncodedHash(s string) bool {
+	if has0xPrefix(s) {
+		s = s[2:]
+	}
+	return len(s) == 2*HashLength && isHex(s)
+}
+
 // Cmp compares two addresses.
 func (a Address) Cmp(other Address) int {
 	return bytes.Compare(a[:], other[:])

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -68,6 +68,32 @@ func TestIsAddress(t *testing.T) {
 	}
 }
 
+func TestIsHexEncodedHash(t *testing.T) {
+	tests := []struct {
+		str string
+		exp bool
+	}{
+		{strings.Repeat("5a", HashLength), true},
+		{"0x" + strings.Repeat("5a", HashLength), true},
+		{"0X" + strings.Repeat("5a", HashLength), true},
+		{strings.Repeat("0", 2*HashLength), true},
+		{"0x" + strings.Repeat("0", 2*HashLength), true},
+		{strings.Repeat("0", 2*HashLength-1), false},
+		{strings.Repeat("0", 2*HashLength+1), false},
+		{"0x" + strings.Repeat("0", 2*HashLength-1), false},
+		{"0x" + strings.Repeat("0", 2*HashLength+1), false},
+		{"0x" + strings.Repeat("0", 2*HashLength-1) + "x", false},
+		{"Q" + strings.Repeat("0", 2*HashLength), false},
+	}
+
+	for _, test := range tests {
+		if result := IsHexEncodedHash(test.str); result != test.exp {
+			t.Errorf("IsHexEncodedHash(%s) == %v; expected %v",
+				test.str, result, test.exp)
+		}
+	}
+}
+
 func TestMustParseAddress(t *testing.T) {
 	input := "Q" + strings.Repeat("5a", AddressLength)
 	if got, want := MustParseAddress(input), BytesToAddress(Hex2Bytes(strings.TrimPrefix(input, "Q"))); got != want {


### PR DESCRIPTION
## Summary

- Fix `gqrl dump --start` and `gqrl snapshot inspect-account` so they parse full QRL addresses instead of checking the old legacy address length.
- Add `common.IsHexEncodedHash` and use it for 32-byte hash inputs with or without a `0x` prefix.
- Update the stale dump error message to describe QRL addresses and hex-encoded 32-byte hashes.

## Tests

- `go test ./common`
- `go test ./cmd/gqrl`
