### PR TITLE
Use U512 for storage proof values

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -36,6 +36,8 @@ import (
 	"math/big"
 	"math/bits"
 	"strconv"
+
+	"github.com/theQRL/go-qrl/common/uint512"
 )
 
 const (
@@ -55,6 +57,7 @@ var (
 	ErrUint64Range    = &decError{"hex number > 64 bits"}
 	ErrUintRange      = &decError{fmt.Sprintf("hex number > %d bits", bits.UintSize)}
 	ErrBig256Range    = &decError{"hex number > 256 bits"}
+	ErrBig512Range    = &decError{fmt.Sprintf("hex number > %d bits", uint512.WordBits)}
 )
 
 type decError struct{ msg string }

--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -36,8 +36,6 @@ import (
 	"math/big"
 	"math/bits"
 	"strconv"
-
-	"github.com/theQRL/go-qrl/common/uint512"
 )
 
 const (
@@ -57,7 +55,7 @@ var (
 	ErrUint64Range    = &decError{"hex number > 64 bits"}
 	ErrUintRange      = &decError{fmt.Sprintf("hex number > %d bits", bits.UintSize)}
 	ErrBig256Range    = &decError{"hex number > 256 bits"}
-	ErrBig512Range    = &decError{fmt.Sprintf("hex number > %d bits", uint512.WordBits)}
+	ErrBig512Range    = &decError{"hex number > 512 bits"}
 )
 
 type decError struct{ msg string }

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -254,6 +254,10 @@ func (b *Big) UnmarshalGraphQL(input any) error {
 // U512 marshals/unmarshals as a JSON quantity with 0x prefix.
 // The zero value marshals as "0x0".
 //
+// U512 is intended for RPC fields that can legitimately carry full-width
+// storage values without relaxing the 256-bit validation enforced by Big for
+// regular protocol quantities.
+//
 // Negative integers are not supported. Values larger than 512 bits are rejected
 // by Unmarshal but will be marshaled without error.
 type U512 big.Int

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -23,12 +23,15 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
+
+	"github.com/theQRL/go-qrl/common/uint512"
 )
 
 var (
 	bytesT  = reflect.TypeFor[Bytes]()
 	bytesqT = reflect.TypeFor[BytesQ]()
 	bigT    = reflect.TypeFor[*Big]()
+	u512T   = reflect.TypeFor[*U512]()
 	uintT   = reflect.TypeFor[Uint]()
 	uint64T = reflect.TypeFor[Uint64]()
 )
@@ -246,6 +249,83 @@ func (b *Big) UnmarshalGraphQL(input any) error {
 		err = fmt.Errorf("unexpected type %T for BigInt", input)
 	}
 	return err
+}
+
+// U512 marshals/unmarshals as a JSON quantity with 0x prefix.
+// The zero value marshals as "0x0".
+//
+// Negative integers are not supported. Values larger than 512 bits are rejected
+// by Unmarshal but will be marshaled without error.
+type U512 big.Int
+
+// MarshalText implements encoding.TextMarshaler.
+func (u U512) MarshalText() ([]byte, error) {
+	return []byte(EncodeBig((*big.Int)(&u))), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (u *U512) UnmarshalJSON(input []byte) error {
+	if !isString(input) {
+		return errNonString(u512T)
+	}
+	return wrapTypeError(u.UnmarshalText(input[1:len(input)-1]), u512T)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (u *U512) UnmarshalText(input []byte) error {
+	raw, err := checkNumberText(input)
+	if err != nil {
+		return err
+	}
+	if len(raw) > uint512.WordBits/4 {
+		return ErrBig512Range
+	}
+	words := make([]big.Word, len(raw)/bigWordNibbles+1)
+	end := len(raw)
+	for i := range words {
+		start := max(end-bigWordNibbles, 0)
+		for ri := start; ri < end; ri++ {
+			nib := decodeNibble(raw[ri])
+			if nib == badNibble {
+				return ErrSyntax
+			}
+			words[i] *= 16
+			words[i] += big.Word(nib)
+		}
+		end = start
+	}
+	var dec big.Int
+	dec.SetBits(words)
+	*u = (U512)(dec)
+	return nil
+}
+
+// ToInt converts u to a big.Int.
+func (u *U512) ToInt() *big.Int {
+	return (*big.Int)(u)
+}
+
+// String returns the hex encoding of u.
+func (u *U512) String() string {
+	return EncodeBig(u.ToInt())
+}
+
+// ImplementsGraphQLType returns true if U512 implements the provided GraphQL type.
+func (u U512) ImplementsGraphQLType(name string) bool { return name == "BigInt" }
+
+// UnmarshalGraphQL unmarshals the provided GraphQL query data.
+func (u *U512) UnmarshalGraphQL(input any) error {
+	switch input := input.(type) {
+	case string:
+		return u.UnmarshalText([]byte(input))
+	case int32:
+		var num big.Int
+		num.SetInt64(int64(input))
+		*u = U512(num)
+		return nil
+	default:
+		return fmt.Errorf("unexpected type %T for U512", input)
+	}
 }
 
 // Uint64 marshals/unmarshals as a JSON string with 0x prefix.

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -34,8 +34,6 @@ var (
 	uint64T = reflect.TypeFor[Uint64]()
 )
 
-const u512HexDigits = 128
-
 // Bytes marshals/unmarshals as a JSON string with 0x prefix.
 // The empty slice marshals as "0x".
 type Bytes []byte
@@ -250,6 +248,8 @@ func (b *Big) UnmarshalGraphQL(input any) error {
 	}
 	return err
 }
+
+const u512HexDigits = 128
 
 // U512 marshals/unmarshals as a JSON quantity with 0x prefix.
 // The zero value marshals as "0x0".

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -23,8 +23,6 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
-
-	"github.com/theQRL/go-qrl/common/uint512"
 )
 
 var (
@@ -35,6 +33,8 @@ var (
 	uintT   = reflect.TypeFor[Uint]()
 	uint64T = reflect.TypeFor[Uint64]()
 )
+
+const u512HexDigits = 128
 
 // Bytes marshals/unmarshals as a JSON string with 0x prefix.
 // The empty slice marshals as "0x".
@@ -277,7 +277,7 @@ func (u *U512) UnmarshalText(input []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(raw) > uint512.WordBits/4 {
+	if len(raw) > u512HexDigits {
 		return ErrBig512Range
 	}
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -206,24 +206,28 @@ func TestMarshalBig(t *testing.T) {
 	}
 }
 
+var unmarshalU512Tests = []unmarshalTest{
+	// invalid encoding
+	{input: "", wantErr: errJSONEOF},
+	{input: "null", wantErr: errNonString(u512T)},
+	{input: "10", wantErr: errNonString(u512T)},
+	{input: `"0"`, wantErr: wrapTypeError(ErrMissingPrefix, u512T)},
+	{input: `"0x"`, wantErr: wrapTypeError(ErrEmptyNumber, u512T)},
+	{input: `"0x01"`, wantErr: wrapTypeError(ErrLeadingZero, u512T)},
+	{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 129)) + `"`, wantErr: wrapTypeError(ErrBig512Range, u512T)},
+	{input: `"0xx"`, wantErr: wrapTypeError(ErrSyntax, u512T)},
+	{input: `"0x1zz01"`, wantErr: wrapTypeError(ErrSyntax, u512T)},
+
+	// valid encoding
+	{input: `""`, want: big.NewInt(0)},
+	{input: `"0x0"`, want: big.NewInt(0)},
+	{input: `"0x2"`, want: big.NewInt(2)},
+	{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 64)) + `"`, want: referenceBig(string(bytes.Repeat([]byte{'f'}, 64)))},
+	{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 128)) + `"`, want: referenceBig(string(bytes.Repeat([]byte{'f'}, 128)))},
+}
+
 func TestUnmarshalU512(t *testing.T) {
-	tests := []unmarshalTest{
-		{input: "", wantErr: errJSONEOF},
-		{input: "null", wantErr: errNonString(u512T)},
-		{input: "10", wantErr: errNonString(u512T)},
-		{input: `"0"`, wantErr: wrapTypeError(ErrMissingPrefix, u512T)},
-		{input: `"0x"`, wantErr: wrapTypeError(ErrEmptyNumber, u512T)},
-		{input: `"0x01"`, wantErr: wrapTypeError(ErrLeadingZero, u512T)},
-		{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 129)) + `"`, wantErr: wrapTypeError(ErrBig512Range, u512T)},
-		{input: `"0xx"`, wantErr: wrapTypeError(ErrSyntax, u512T)},
-		{input: `"0x1zz01"`, wantErr: wrapTypeError(ErrSyntax, u512T)},
-		{input: `""`, want: big.NewInt(0)},
-		{input: `"0x0"`, want: big.NewInt(0)},
-		{input: `"0x2"`, want: big.NewInt(2)},
-		{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 64)) + `"`, want: referenceBig(string(bytes.Repeat([]byte{'f'}, 64)))},
-		{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 128)) + `"`, want: referenceBig(string(bytes.Repeat([]byte{'f'}, 128)))},
-	}
-	for _, test := range tests {
+	for _, test := range unmarshalU512Tests {
 		var v U512
 		err := json.Unmarshal([]byte(test.input), &v)
 		if !checkError(t, test.input, err, test.wantErr) {

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -206,6 +206,50 @@ func TestMarshalBig(t *testing.T) {
 	}
 }
 
+func TestUnmarshalU512(t *testing.T) {
+	tests := []unmarshalTest{
+		{input: "", wantErr: errJSONEOF},
+		{input: "null", wantErr: errNonString(u512T)},
+		{input: "10", wantErr: errNonString(u512T)},
+		{input: `"0"`, wantErr: wrapTypeError(ErrMissingPrefix, u512T)},
+		{input: `"0x"`, wantErr: wrapTypeError(ErrEmptyNumber, u512T)},
+		{input: `"0x01"`, wantErr: wrapTypeError(ErrLeadingZero, u512T)},
+		{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 129)) + `"`, wantErr: wrapTypeError(ErrBig512Range, u512T)},
+		{input: `"0xx"`, wantErr: wrapTypeError(ErrSyntax, u512T)},
+		{input: `"0x1zz01"`, wantErr: wrapTypeError(ErrSyntax, u512T)},
+		{input: `""`, want: big.NewInt(0)},
+		{input: `"0x0"`, want: big.NewInt(0)},
+		{input: `"0x2"`, want: big.NewInt(2)},
+		{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 64)) + `"`, want: referenceBig(string(bytes.Repeat([]byte{'f'}, 64)))},
+		{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 128)) + `"`, want: referenceBig(string(bytes.Repeat([]byte{'f'}, 128)))},
+	}
+	for _, test := range tests {
+		var v U512
+		err := json.Unmarshal([]byte(test.input), &v)
+		if !checkError(t, test.input, err, test.wantErr) {
+			continue
+		}
+		if test.want != nil && test.want.(*big.Int).Cmp((*big.Int)(&v)) != 0 {
+			t.Errorf("input %s: value mismatch: got %x, want %x", test.input, (*big.Int)(&v), test.want)
+		}
+	}
+}
+
+func TestMarshalU512(t *testing.T) {
+	in := referenceBig(string(bytes.Repeat([]byte{'f'}, 128)))
+	out, err := json.Marshal((*U512)(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `"0x` + string(bytes.Repeat([]byte{'f'}, 128)) + `"`
+	if string(out) != want {
+		t.Fatalf("MarshalJSON output mismatch: got %q, want %q", out, want)
+	}
+	if got := (*U512)(in).String(); got != want[1:len(want)-1] {
+		t.Fatalf("String mismatch: got %q, want %q", got, want[1:len(want)-1])
+	}
+}
+
 var unmarshalUint64Tests = []unmarshalTest{
 	// invalid encoding
 	{input: "", wantErr: errJSONEOF},

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -226,6 +226,13 @@ var unmarshalU512Tests = []unmarshalTest{
 	{input: `"0x` + string(bytes.Repeat([]byte{'f'}, 128)) + `"`, want: referenceBig(string(bytes.Repeat([]byte{'f'}, 128)))},
 }
 
+var encodeU512Tests = []marshalTest{
+	{referenceBig("0"), "0x0"},
+	{referenceBig("2"), "0x2"},
+	{referenceBig(string(bytes.Repeat([]byte{'f'}, 64))), "0x" + string(bytes.Repeat([]byte{'f'}, 64))},
+	{referenceBig(string(bytes.Repeat([]byte{'f'}, 128))), "0x" + string(bytes.Repeat([]byte{'f'}, 128))},
+}
+
 func TestUnmarshalU512(t *testing.T) {
 	for _, test := range unmarshalU512Tests {
 		var v U512
@@ -240,17 +247,21 @@ func TestUnmarshalU512(t *testing.T) {
 }
 
 func TestMarshalU512(t *testing.T) {
-	in := referenceBig(string(bytes.Repeat([]byte{'f'}, 128)))
-	out, err := json.Marshal((*U512)(in))
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := `"0x` + string(bytes.Repeat([]byte{'f'}, 128)) + `"`
-	if string(out) != want {
-		t.Fatalf("MarshalJSON output mismatch: got %q, want %q", out, want)
-	}
-	if got := (*U512)(in).String(); got != want[1:len(want)-1] {
-		t.Fatalf("String mismatch: got %q, want %q", got, want[1:len(want)-1])
+	for _, test := range encodeU512Tests {
+		in := test.input.(*big.Int)
+		out, err := json.Marshal((*U512)(in))
+		if err != nil {
+			t.Errorf("%d: %v", in, err)
+			continue
+		}
+		if want := `"` + test.want + `"`; string(out) != want {
+			t.Errorf("%d: MarshalJSON output mismatch: got %q, want %q", in, out, want)
+			continue
+		}
+		if out := (*U512)(in).String(); out != test.want {
+			t.Errorf("%x: String mismatch: got %q, want %q", in, out, test.want)
+			continue
+		}
 	}
 }
 

--- a/internal/qrlapi/api.go
+++ b/internal/qrlapi/api.go
@@ -319,9 +319,9 @@ type AccountResult struct {
 }
 
 type StorageResult struct {
-	Key   string       `json:"key"`
-	Value *hexutil.Big `json:"value"`
-	Proof []string     `json:"proof"`
+	Key   string        `json:"key"`
+	Value *hexutil.U512 `json:"value"`
+	Proof []string      `json:"proof"`
 }
 
 // proofList implements qrldb.KeyValueWriter and collects the proofs as
@@ -382,14 +382,14 @@ func (api *BlockChainAPI) GetProof(ctx context.Context, address common.Address, 
 				outputKey = hexutil.Encode(key[:])
 			}
 			if storageTrie == nil {
-				storageProof[i] = StorageResult{outputKey, &hexutil.Big{}, []string{}}
+				storageProof[i] = StorageResult{outputKey, &hexutil.U512{}, []string{}}
 				continue
 			}
 			var proof proofList
 			if err := storageTrie.Prove(crypto.Keccak256(key.Bytes()), &proof); err != nil {
 				return nil, err
 			}
-			value := (*hexutil.Big)(statedb.GetState(address, key).Big())
+			value := (*hexutil.U512)(statedb.GetState(address, key).Big())
 			storageProof[i] = StorageResult{outputKey, value, proof}
 		}
 	}

--- a/internal/qrlapi/api_test.go
+++ b/internal/qrlapi/api_test.go
@@ -17,6 +17,7 @@
 package qrlapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -107,6 +108,47 @@ func TestTransaction_RoundTripRpcJSON(t *testing.T) {
 		tests[i].Want = ""
 	}
 	testTransactionMarshal(t, tests, config)
+}
+
+func TestGetProofStorageValue64Quantity(t *testing.T) {
+	t.Parallel()
+
+	var (
+		addr    = common.BytesToAddress(bytes.Repeat([]byte{0x11}, common.AddressLength))
+		slot    = common.HexToHash("0x01")
+		value   = common.BytesToStorageValue64(bytes.Repeat([]byte{0x42}, common.StorageValue64Length))
+		genesis = &core.Genesis{
+			Config: params.TestChainConfig,
+			Alloc: core.GenesisAlloc{
+				addr: {
+					Balance: big.NewInt(1),
+					Storage: map[common.Hash]common.StorageValue64{
+						slot: value,
+					},
+				},
+			},
+		}
+		api = NewBlockChainAPI(newTestBackend(t, 1, genesis, beacon.NewFaker(), func(i int, b *core.BlockGen) {}))
+	)
+
+	result, err := api.GetProof(t.Context(), addr, []string{slot.Hex()}, rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.StorageProof) != 1 {
+		t.Fatalf("storage proof length mismatch: have %d, want 1", len(result.StorageProof))
+	}
+	if result.StorageProof[0].Value.ToInt().BitLen() <= 256 {
+		t.Fatalf("storage proof value does not exercise high 256 bits: %s", result.StorageProof[0].Value)
+	}
+	got, err := json.Marshal(result.StorageProof[0].Value)
+	if err != nil {
+		t.Fatalf("marshal storage proof value: %v", err)
+	}
+	want := `"` + hexutil.EncodeBig(value.Big()) + `"`
+	if string(got) != want {
+		t.Fatalf("storage proof value JSON mismatch:\nhave %s\nwant %s", got, want)
+	}
 }
 
 func TestRPCTransactionPreservesExtraParams(t *testing.T) {

--- a/qrlclient/gqrlclient/gqrlclient.go
+++ b/qrlclient/gqrlclient/gqrlclient.go
@@ -82,9 +82,9 @@ type StorageResult struct {
 // The block number can be nil, in which case the value is taken from the latest known block.
 func (qc *Client) GetProof(ctx context.Context, account common.Address, keys []string, blockNumber *big.Int) (*AccountResult, error) {
 	type storageResult struct {
-		Key   string       `json:"key"`
-		Value *hexutil.Big `json:"value"`
-		Proof []string     `json:"proof"`
+		Key   string        `json:"key"`
+		Value *hexutil.U512 `json:"value"`
+		Proof []string      `json:"proof"`
 	}
 
 	type accountResult struct {
@@ -265,19 +265,19 @@ type OverrideAccount struct {
 	// State sets the complete storage. The override will be applied
 	// when the given map is non-nil. Using an empty map wipes the
 	// entire contract storage during the call.
-	State map[common.Hash]common.Hash
+	State map[common.Hash]common.StorageValue64
 
 	// StateDiff allows overriding individual storage slots.
-	StateDiff map[common.Hash]common.Hash
+	StateDiff map[common.Hash]common.StorageValue64
 }
 
 func (a OverrideAccount) MarshalJSON() ([]byte, error) {
 	type acc struct {
-		Nonce     hexutil.Uint64              `json:"nonce,omitempty"`
-		Code      string                      `json:"code,omitempty"`
-		Balance   *hexutil.Big                `json:"balance,omitempty"`
-		State     any                         `json:"state,omitempty"`
-		StateDiff map[common.Hash]common.Hash `json:"stateDiff,omitempty"`
+		Nonce     hexutil.Uint64                        `json:"nonce,omitempty"`
+		Code      string                                `json:"code,omitempty"`
+		Balance   *hexutil.Big                          `json:"balance,omitempty"`
+		State     any                                   `json:"state,omitempty"`
+		StateDiff map[common.Hash]common.StorageValue64 `json:"stateDiff,omitempty"`
 	}
 
 	output := acc{

--- a/qrlclient/gqrlclient/gqrlclient_test.go
+++ b/qrlclient/gqrlclient/gqrlclient_test.go
@@ -45,7 +45,7 @@ var (
 	testContract = common.BytesToAddress(common.FromHex("000000000000000000000000000000000000beef000000000000000000000000000000000000beef11223344556677"))
 	testEmpty    = common.BytesToAddress(common.FromHex("000000000000000000000000000000000000eeee000000000000000000000000000000000000eeee11223344556677"))
 	testSlot     = common.HexToHash("0xdeadbeef")
-	testValue    = common.BytesToStorageValue64(crypto.Keccak256Hash(testSlot[:]).Bytes())
+	testValue    = common.BytesToStorageValue64(bytes.Repeat([]byte{0x42}, common.StorageValue64Length))
 	testBalance  = big.NewInt(2e18)
 )
 
@@ -256,8 +256,11 @@ func testGetProof(t *testing.T, client *rpc.Client, addr common.Address) {
 		if proof.Key != testSlot.String() {
 			t.Fatalf("invalid storage proof key, want: %q, got: %q", testSlot.String(), proof.Key)
 		}
-		slotValue, _ := qrlcl.StorageAt(t.Context(), addr, common.HexToHash(proof.Key), nil)
-		if have, want := common.BigToHash(proof.Value), common.BytesToHash(slotValue); have != want {
+		slotValue, err := qrlcl.StorageAt(t.Context(), addr, common.HexToHash(proof.Key), nil)
+		if err != nil {
+			t.Fatalf("failed to fetch storage for %x: %v", addr, err)
+		}
+		if have, want := common.BytesToStorageValue64(proof.Value.Bytes()), common.BytesToStorageValue64(slotValue); have != want {
 			t.Fatalf("addr %x, invalid storage proof value: have: %v, want: %v", addr, have, want)
 		}
 	}
@@ -484,10 +487,15 @@ func TestOverrideAccountMarshal(t *testing.T) {
 			// a non-nil but empty value.
 			Code:    []byte{},
 			Balance: big.NewInt(0),
-			State:   map[common.Hash]common.Hash{},
+			State:   map[common.Hash]common.StorageValue64{},
 			// For 'stateDiff' the behavior is different, empty map
 			// is ignored because it makes no difference.
-			StateDiff: map[common.Hash]common.Hash{},
+			StateDiff: map[common.Hash]common.StorageValue64{},
+		},
+		{0xdd}: {
+			StateDiff: map[common.Hash]common.StorageValue64{
+				{0x01}: common.BytesToStorageValue64(bytes.Repeat([]byte{0x22}, common.StorageValue64Length)),
+			},
 		},
 	}
 
@@ -511,6 +519,11 @@ func TestOverrideAccountMarshal(t *testing.T) {
   },
   "QaA000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000": {
     "nonce": "0x5"
+  },
+  "Qdd000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000": {
+    "stateDiff": {
+      "0x0100000000000000000000000000000000000000000000000000000000000000": "0x22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222"
+    }
   }
 }`
 


### PR DESCRIPTION
## Summary

- Add `hexutil.U512` and use it for `qrl_getProof` storage proof values that can contain full-width `StorageValue64` data.
- Decode qrlclient proof values through `hexutil.U512` so full-width values round-trip to the public `*big.Int` result.
- Marshal qrlclient override `State` and `StateDiff` values as `common.StorageValue64`.

## Rationale

`hexutil.Big` is intentionally capped to 256-bit values when unmarshalling JSON quantities: `common/hexutil/json.go:202` rejects inputs where `len(raw) > 64` with `ErrBig256Range`. Storage proof values are `common.StorageValue64`, so a proof can contain a full 512-bit value that `hexutil.Big` can marshal but cannot decode back.

This keeps the wider bound local to storage proof values instead of raising the cap on `hexutil.Big` globally, which would relax validation for unrelated RPC fields such as balances, transaction values, gas fee fields, block numbers, and chain IDs.

## Compatibility

`gqrlclient.OverrideAccount.State` and `StateDiff` now use `common.StorageValue64` values instead of `common.Hash` values, matching the current full-width storage model. Downstream callers constructing storage overrides should convert values with `common.BytesToStorageValue64` or `common.HexToStorageValue64` as appropriate.

## Tests

- `go test ./common/hexutil`
- `go test ./internal/qrlapi`
- `go test ./qrlclient/gqrlclient`