### PR TITLE
[FIX] Format web3ext log topics as VM64 topics

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -394,6 +394,48 @@ web3._extend({
 `
 
 const QRLJs = `
+var qrlLogTopicFormatter = function(topic) {
+	if (topic === null || typeof topic === 'undefined') {
+		return null;
+	}
+	topic = String(topic);
+	topic = topic.slice(0, 2).toLowerCase() === '0x' ? topic : web3._extend.utils.fromUtf8(topic);
+	var hex = topic.slice(0, 2).toLowerCase() === '0x' ? topic.slice(2) : topic;
+	if (hex.length > 128) {
+		throw new Error('invalid topic length');
+	}
+	return '0x' + web3._extend.utils.padLeft(hex, 128);
+};
+
+var qrlInputLogFormatter = function(options) {
+	options = options || {};
+	if (options.fromBlock !== undefined) {
+		options.fromBlock = web3._extend.formatters.inputBlockNumberFormatter(options.fromBlock);
+	}
+	if (options.toBlock !== undefined) {
+		options.toBlock = web3._extend.formatters.inputBlockNumberFormatter(options.toBlock);
+	}
+	if (options.address !== undefined) {
+		if (web3._extend.utils.isArray(options.address)) {
+			options.address = options.address.map(web3._extend.formatters.inputAddressFormatter);
+		} else {
+			options.address = web3._extend.formatters.inputAddressFormatter(options.address);
+		}
+	}
+	options.topics = options.topics || [];
+	options.topics = options.topics.map(function(topic) {
+		return web3._extend.utils.isArray(topic) ? topic.map(qrlLogTopicFormatter) : qrlLogTopicFormatter(topic);
+	});
+	return options;
+};
+
+var qrlOutputLogArrayFormatter = function(logs) {
+	if (!web3._extend.utils.isArray(logs)) {
+		return logs;
+	}
+	return logs.map(web3._extend.formatters.outputLogFormatter);
+};
+
 web3._extend({
 	property: 'qrl',
 	methods: [
@@ -491,6 +533,8 @@ web3._extend({
 			name: 'getLogs',
 			call: 'qrl_getLogs',
 			params: 1,
+			inputFormatter: [qrlInputLogFormatter],
+			outputFormatter: qrlOutputLogArrayFormatter,
 		}),
 		new web3._extend.Method({
 			name: 'call',

--- a/internal/web3ext/web3ext_test.go
+++ b/internal/web3ext/web3ext_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The go-QRL Authors
+// This file is part of the go-QRL library.
+//
+// The go-QRL library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-QRL library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-QRL library. If not, see <http://www.gnu.org/licenses/>.
+
+package web3ext
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	qrljsre "github.com/theQRL/go-qrl/internal/jsre"
+	"github.com/theQRL/go-qrl/internal/jsre/deps"
+)
+
+func TestQRLGetLogsFormatsVM64Topics(t *testing.T) {
+	t.Parallel()
+
+	re := qrljsre.New("", io.Discard)
+	defer re.Stop(false)
+
+	if err := re.Compile("bignumber.js", deps.BigNumberJS); err != nil {
+		t.Fatalf("compile bignumber.js: %v", err)
+	}
+	if err := re.Compile("web3.js", deps.Web3JS); err != nil {
+		t.Fatalf("compile web3.js: %v", err)
+	}
+	if _, err := re.Run(`
+var capturedOptions = null;
+var provider = {
+  send: function(payload) {
+    if (payload.method === "qrl_getLogs") {
+      capturedOptions = payload.params[0];
+    }
+    return {jsonrpc: "2.0", id: payload.id, result: []};
+  },
+  sendAsync: function(payload, cb) {
+    if (payload.method === "qrl_getLogs") {
+      capturedOptions = payload.params[0];
+    }
+    cb(null, {jsonrpc: "2.0", id: payload.id, result: []});
+  },
+  isConnected: function() { return true; }
+};
+var Web3 = require("web3");
+var web3 = new Web3(provider);
+`); err != nil {
+		t.Fatalf("init web3: %v", err)
+	}
+	if err := re.Compile("qrl.js", QRLJs); err != nil {
+		t.Fatalf("compile qrl.js: %v", err)
+	}
+
+	const address = "Q00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	value, err := re.Run(fmt.Sprintf(`
+web3.qrl.getLogs({
+  fromBlock: "0x1",
+  toBlock: "latest",
+  address: %q,
+  topics: ["0xbb", null, ["0xcc", "hello"]]
+});
+JSON.stringify(capturedOptions);
+`, address))
+	if err != nil {
+		t.Fatalf("run getLogs script: %v", err)
+	}
+	var got struct {
+		FromBlock string `json:"fromBlock"`
+		ToBlock   string `json:"toBlock"`
+		Address   string `json:"address"`
+		Topics    []any  `json:"topics"`
+	}
+	if err := json.Unmarshal([]byte(value.String()), &got); err != nil {
+		t.Fatalf("decode captured options %q: %v", value.String(), err)
+	}
+	if got.FromBlock != "0x1" || got.ToBlock != "latest" || got.Address != address {
+		t.Fatalf("unexpected filter fields: %#v", got)
+	}
+	if len(got.Topics) != 3 {
+		t.Fatalf("topic count mismatch: have %d want 3", len(got.Topics))
+	}
+	if got.Topics[0] != vm64Topic("bb") {
+		t.Fatalf("short hex topic mismatch: have %#v", got.Topics[0])
+	}
+	if got.Topics[1] != nil {
+		t.Fatalf("wildcard topic mismatch: have %#v", got.Topics[1])
+	}
+	orTopics, ok := got.Topics[2].([]any)
+	if !ok || len(orTopics) != 2 {
+		t.Fatalf("OR topic mismatch: %#v", got.Topics[2])
+	}
+	if orTopics[0] != vm64Topic("cc") {
+		t.Fatalf("OR hex topic mismatch: have %#v", orTopics[0])
+	}
+	if orTopics[1] != vm64Topic("68656c6c6f") {
+		t.Fatalf("string topic mismatch: have %#v", orTopics[1])
+	}
+
+	if _, err := re.Run(`web3.qrl.getLogs({topics: ["0x` + strings.Repeat("1", 129) + `"]});`); err == nil {
+		t.Fatal("expected over-wide topic to be rejected")
+	}
+}
+
+func vm64Topic(hex string) string {
+	return "0x" + strings.Repeat("0", 128-len(hex)) + hex
+}


### PR DESCRIPTION
## Summary

- Format `web3.qrl.getLogs` filter topics as 64-byte VM64 log topics before sending `qrl_getLogs`.
- Preserve null wildcards and nested OR-topic lists while rejecting topics wider than 64 bytes.
- Add a JSRE/web3ext regression test that captures the RPC payload.

## Tests

- `go test -count=1 ./internal/web3ext`
- `go test -count=1 ./internal/jsre ./internal/web3ext ./console`
- `go test ./...`
