### PR TITLE
[DOCS] Clarify VM64 gas word comments

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -23,7 +23,7 @@ const (
 	GenesisGasLimit      uint64 = 4712388  // Gas limit of the Genesis block.
 
 	MaximumExtraDataSize  uint64 = 32    // Maximum size extra data may be after Genesis.
-	SloadGas              uint64 = 50    // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
+	SloadGas              uint64 = 50    // Cost of an SLOAD operation.
 	CallValueTransferGas  uint64 = 9000  // Paid for CALL when the value transfer is non-zero.
 	CallNewAccountGas     uint64 = 25000 // Paid for CALL when the destination address didn't exist prior.
 	TxGas                 uint64 = 21000 // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
@@ -34,8 +34,8 @@ const (
 	CallStipend           uint64 = 2300  // Free gas given at beginning of call.
 
 	Keccak256Gas     uint64 = 30 // Once per KECCAK256 operation.
-	Keccak256WordGas uint64 = 6  // Once per word of the KECCAK256 operation's data.
-	InitCodeWordGas  uint64 = 2  // Once per word of the init code when creating a contract.
+	Keccak256WordGas uint64 = 6  // Once per 64-byte VM word of the KECCAK256 operation's data.
+	InitCodeWordGas  uint64 = 2  // Once per 64-byte VM word of the init code when creating a contract.
 
 	SstoreSentryGasEIP2200            uint64 = 2300  // Minimum gas required to be present for an SSTORE call, not consumed
 	SstoreSetGasEIP2200               uint64 = 20000 // Once per SSTORE operation from clean zero to non-zero
@@ -85,9 +85,9 @@ const (
 	// Precompiled contract gas prices
 	DepositrootGas     uint64 = 3000 // Deposit root operation gas price
 	Sha256BaseGas      uint64 = 60   // Base price for a SHA256 operation
-	Sha256PerWordGas   uint64 = 12   // Per-word price for a SHA256 operation
+	Sha256PerWordGas   uint64 = 12   // Per 64-byte VM word price for a SHA256 operation
 	IdentityBaseGas    uint64 = 15   // Base price for a data copy operation
-	IdentityPerWordGas uint64 = 3    // Per-work price for a data copy operation
+	IdentityPerWordGas uint64 = 3    // Per 64-byte VM word price for a data copy operation
 
 	// The Refund Quotient is the cap on how much of the used gas can be refunded. Before EIP-3529,
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529


### PR DESCRIPTION
## Summary
- Clarify gas comments that refer to VM word-sized accounting.
- Fix the stale `SloadGas` comment so it describes SLOAD cost instead of copy-word accounting.

## Tests
- `go test ./params`
