### PR TITLE
Fix stale qubes.EthSign references in Clef docs

### DIFF
--- a/cmd/clef/docs/qubes/qubes-client.py
+++ b/cmd/clef/docs/qubes/qubes-client.py
@@ -1,6 +1,6 @@
 """
 This implements a dispatcher which listens to localhost:8550, and proxies
-requests via qrexec to the service qubes.EthSign on a target domain
+requests via qrexec to the service qubes.Clefsign on a target domain
 """
 
 import http.server
@@ -20,4 +20,3 @@ class Dispatcher(http.server.BaseHTTPRequestHandler):
 with socketserver.TCPServer(("",PORT), Dispatcher) as httpd:
     print("Serving at port", PORT)
     httpd.serve_forever()
-

--- a/cmd/clef/docs/setup.md
+++ b/cmd/clef/docs/setup.md
@@ -100,7 +100,7 @@ On the `client` qube, we need to create a listener which will receive the reques
 
 """
 This implements a dispatcher which listens to localhost:8550, and proxies
-requests via qrexec to the service qubes.EthSign on a target domain
+requests via qrexec to the service qubes.Clefsign on a target domain
 """
 
 import http.server
@@ -195,4 +195,3 @@ ever connects to a local network between your computer and the device itself.
 
 Needless to say, while this model should be fairly secure against remote attacks, an attacker with physical access
 to the USB Armory would trivially be able to extract the contents of the device filesystem. 
-


### PR DESCRIPTION
## Summary
- Update Clef Qubes docs to refer to the current `qubes.Clefsign` service name.
- Align the prose with the existing qrexec command examples.

## Tests
- `git diff --check`
- `rg -n "qubes\.EthSign" cmd/clef/docs/qubes/qubes-client.py cmd/clef/docs/setup.md` returns no matches
