### PR TITLE
Fix stale theqrl/gqrl Docker image references

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Docker:
 ```shell
 docker run -d --name qrl-node -v /Users/alice/qrl:/root \
            -p 8545:8545 -p 30303:30303 \
-           theqrl/gqrl
+           qrledger/go-qrl
 ```
 
 This will start `gqrl` in snap-sync mode with a DB memory allowance of 1GB, as the

--- a/build/ci.go
+++ b/build/ci.go
@@ -372,14 +372,14 @@ func doDockerBuildx(cmdline []string) {
 		build.MustRun(auther)
 	}
 	// Retrieve the version infos to build and push to the following paths:
-	//  - theqrl/gqrl:latest                            - Pushes to the main branch, Gqrl only
-	//  - theqrl/gqrl:stable                            - Version tag publish on GitHub, Gqrl only
-	//  - theqrl/gqrl:alltools-latest                   - Pushes to the main branch, Gqrl & tools
-	//  - theqrl/gqrl:alltools-stable                   - Version tag publish on GitHub, Gqrl & tools
-	//  - theqrl/gqrl:release-<major>.<minor>           - Version tag publish on GitHub, Gqrl only
-	//  - theqrl/gqrl:alltools-release-<major>.<minor>  - Version tag publish on GitHub, Gqrl & tools
-	//  - theqrl/gqrl:v<major>.<minor>.<patch>          - Version tag publish on GitHub, Gqrl only
-	//  - theqrl/gqrl:alltools-v<major>.<minor>.<patch> - Version tag publish on GitHub, Gqrl & tools
+	//  - qrledger/go-qrl:latest                            - Pushes to the main branch, Gqrl only
+	//  - qrledger/go-qrl:stable                            - Version tag publish on GitHub, Gqrl only
+	//  - qrledger/go-qrl:alltools-latest                   - Pushes to the main branch, Gqrl & tools
+	//  - qrledger/go-qrl:alltools-stable                   - Version tag publish on GitHub, Gqrl & tools
+	//  - qrledger/go-qrl:release-<major>.<minor>           - Version tag publish on GitHub, Gqrl only
+	//  - qrledger/go-qrl:alltools-release-<major>.<minor>  - Version tag publish on GitHub, Gqrl & tools
+	//  - qrledger/go-qrl:v<major>.<minor>.<patch>          - Version tag publish on GitHub, Gqrl only
+	//  - qrledger/go-qrl:alltools-v<major>.<minor>.<patch> - Version tag publish on GitHub, Gqrl & tools
 	var tags []string
 
 	switch {


### PR DESCRIPTION
## Summary
- Update the README Docker quick-start image to `qrledger/go-qrl`.
- Update the release tag examples in `build/ci.go` to match the current Docker Hub image target.

## Tests
- `go test ./internal/build`
- `git diff --check`