### PR TITLE
[FIX] Validate ABI dynamic offsets and tail padding

### DIFF
--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -182,17 +182,23 @@ func (arguments Arguments) copyTuple(v any, marshalledValues []any) error {
 // without supplying a struct to unpack into. Instead, this method returns a list containing the
 // values. An atomic argument will be a list with one element.
 func (arguments Arguments) UnpackValues(data []byte) ([]any, error) {
+	if len(data)%abiWordBytes != 0 {
+		return nil, fmt.Errorf("abi: improperly formatted output: %q - Bytes: %+v", data, data)
+	}
 	var (
 		retval      = make([]any, 0)
 		virtualArgs = 0
 		index       = 0
 	)
 
-	for _, arg := range arguments {
-		if arg.Indexed {
-			continue
-		}
-		marshalledValue, err := toGoType((index+virtualArgs)*64, arg.Type, data)
+	nonIndexedArgs := arguments.NonIndexed()
+	headSize := 0
+	for _, arg := range nonIndexedArgs {
+		headSize += getTypeSize(arg.Type)
+	}
+
+	for _, arg := range nonIndexedArgs {
+		marshalledValue, err := toGoTypeWithMinDynamicOffset((index+virtualArgs)*abiWordBytes, arg.Type, data, headSize)
 		if err != nil {
 			return nil, err
 		}
@@ -207,11 +213,11 @@ func (arguments Arguments) UnpackValues(data []byte) ([]any, error) {
 			//
 			// Calculate the full array size to get the correct offset for the next argument.
 			// Decrement it by 1, as the normal index increment is still applied.
-			virtualArgs += getTypeSize(arg.Type)/64 - 1
+			virtualArgs += getTypeSize(arg.Type)/abiWordBytes - 1
 		} else if arg.Type.T == TupleTy && !isDynamicType(arg.Type) {
 			// If we have a static tuple, like (uint256, bool, uint256), these are
 			// coded as just like uint256,bool,uint256
-			virtualArgs += getTypeSize(arg.Type)/64 - 1
+			virtualArgs += getTypeSize(arg.Type)/abiWordBytes - 1
 		}
 		retval = append(retval, marshalledValue)
 		index++

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -17,7 +17,6 @@
 package abi
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -108,12 +107,12 @@ func ReadInteger(typ Type, b []byte) (any, error) {
 
 // readBool reads a bool.
 func readBool(word []byte) (bool, error) {
-	for _, b := range word[:63] {
+	for _, b := range word[:abiWordBytes-1] {
 		if b != 0 {
 			return false, errBadBool
 		}
 	}
-	switch word[63] {
+	switch word[abiWordBytes-1] {
 	case 0:
 		return false, nil
 	case 1:
@@ -161,8 +160,17 @@ func forEachUnpack(t Type, output []byte, start, size int) (any, error) {
 	if size < 0 {
 		return nil, fmt.Errorf("cannot marshal input to array, size is negative (%d)", size)
 	}
-	if start+64*size > len(output) {
-		return nil, fmt.Errorf("abi: cannot marshal into go array: offset %d would go over slice boundary (len=%d)", len(output), start+64*size)
+
+	// Walk elements by their encoded size. Static aggregate elements can occupy
+	// multiple ABI words; dynamic elements occupy one offset word.
+	elemSize := getTypeSize(*t.Elem)
+	maxInt := int(^uint(0) >> 1)
+	if start < 0 || size > 0 && elemSize > (maxInt-start)/size {
+		return nil, fmt.Errorf("abi: cannot marshal into go array: size overflow")
+	}
+	end := start + elemSize*size
+	if end > len(output) {
+		return nil, fmt.Errorf("abi: cannot marshal into go array: offset %d would go over slice boundary (len=%d)", end, len(output))
 	}
 
 	// this value will become our slice or our array, depending on the type
@@ -179,12 +187,8 @@ func forEachUnpack(t Type, output []byte, start, size int) (any, error) {
 		return nil, errors.New("abi: invalid type in array/slice unpacking stage")
 	}
 
-	// Arrays have packed elements, resulting in longer unpack steps.
-	// Slices have just 32 bytes per element (pointing to the contents).
-	elemSize := getTypeSize(*t.Elem)
-
 	for i, j := start, 0; j < size; i, j = i+elemSize, j+1 {
-		inter, err := toGoType(i, *t.Elem, output)
+		inter, err := toGoTypeWithMinDynamicOffset(i, *t.Elem, output, end)
 		if err != nil {
 			return nil, err
 		}
@@ -200,8 +204,12 @@ func forEachUnpack(t Type, output []byte, start, size int) (any, error) {
 func forTupleUnpack(t Type, output []byte) (any, error) {
 	retval := reflect.New(t.GetType()).Elem()
 	virtualArgs := 0
+	headSize := 0
+	for _, elem := range t.TupleElems {
+		headSize += getTypeSize(*elem)
+	}
 	for index, elem := range t.TupleElems {
-		marshalledValue, err := toGoType((index+virtualArgs)*64, *elem, output)
+		marshalledValue, err := toGoTypeWithMinDynamicOffset((index+virtualArgs)*abiWordBytes, *elem, output, headSize)
 		if err != nil {
 			return nil, err
 		}
@@ -216,11 +224,11 @@ func forTupleUnpack(t Type, output []byte) (any, error) {
 			//
 			// Calculate the full array size to get the correct offset for the next argument.
 			// Decrement it by 1, as the normal index increment is still applied.
-			virtualArgs += getTypeSize(*elem)/64 - 1
+			virtualArgs += getTypeSize(*elem)/abiWordBytes - 1
 		} else if elem.T == TupleTy && !isDynamicType(*elem) {
 			// If we have a static tuple, like (uint256, bool, uint256), these are
 			// coded as just like uint256,bool,uint256
-			virtualArgs += getTypeSize(*elem)/64 - 1
+			virtualArgs += getTypeSize(*elem)/abiWordBytes - 1
 		}
 		retval.Field(index).Set(reflect.ValueOf(marshalledValue))
 	}
@@ -230,8 +238,12 @@ func forTupleUnpack(t Type, output []byte) (any, error) {
 // toGoType parses the output bytes and recursively assigns the value of these bytes
 // into a go type with accordance with the ABI spec.
 func toGoType(index int, t Type, output []byte) (any, error) {
-	if index+64 > len(output) {
-		return nil, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), index+64)
+	return toGoTypeWithMinDynamicOffset(index, t, output, index+abiWordBytes)
+}
+
+func toGoTypeWithMinDynamicOffset(index int, t Type, output []byte, minDynamicOffset int) (any, error) {
+	if index+abiWordBytes > len(output) {
+		return nil, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), index+abiWordBytes)
 	}
 
 	var (
@@ -242,18 +254,18 @@ func toGoType(index int, t Type, output []byte) (any, error) {
 
 	// if we require a length prefix, find the beginning word and size returned.
 	if t.requiresLengthPrefix() {
-		begin, length, err = lengthPrefixPointsTo(index, output)
+		begin, length, err = lengthPrefixPointsTo(index, output, minDynamicOffset)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		returnOutput = output[index : index+64]
+		returnOutput = output[index : index+abiWordBytes]
 	}
 
 	switch t.T {
 	case TupleTy:
 		if isDynamicType(t) {
-			begin, err := tuplePointsTo(index, output)
+			begin, err := tuplePointsTo(index, output, minDynamicOffset)
 			if err != nil {
 				return nil, err
 			}
@@ -264,14 +276,17 @@ func toGoType(index int, t Type, output []byte) (any, error) {
 		return forEachUnpack(t, output[begin:], 0, length)
 	case ArrayTy:
 		if isDynamicType(*t.Elem) {
-			offset := binary.BigEndian.Uint64(returnOutput[len(returnOutput)-8:])
-			if offset > uint64(len(output)) {
-				return nil, fmt.Errorf("abi: toGoType offset greater than output length: offset: %d, len(output): %d", offset, len(output))
+			offset, err := tuplePointsTo(index, output, minDynamicOffset)
+			if err != nil {
+				return nil, err
 			}
 			return forEachUnpack(t, output[offset:], 0, t.Size)
 		}
 		return forEachUnpack(t, output[index:], 0, t.Size)
 	case StringTy: // variable arrays are written at the end of the return bytes
+		if err := validateDynamicPayloadPadding(output, begin, length); err != nil {
+			return nil, err
+		}
 		return string(output[begin : begin+length]), nil
 	case IntTy, UintTy:
 		return ReadInteger(t, returnOutput)
@@ -282,6 +297,9 @@ func toGoType(index int, t Type, output []byte) (any, error) {
 	case HashTy:
 		return common.BytesToHash(returnOutput), nil
 	case BytesTy:
+		if err := validateDynamicPayloadPadding(output, begin, length); err != nil {
+			return nil, err
+		}
 		return output[begin : begin+length], nil
 	case FixedBytesTy:
 		return ReadFixedBytes(t, returnOutput)
@@ -292,24 +310,28 @@ func toGoType(index int, t Type, output []byte) (any, error) {
 	}
 }
 
-// lengthPrefixPointsTo interprets a 64 byte slice as an offset and then determines which indices to look to decode the type.
-func lengthPrefixPointsTo(index int, output []byte) (start int, length int, err error) {
-	bigOffsetEnd := new(big.Int).SetBytes(output[index : index+64])
-	bigOffsetEnd.Add(bigOffsetEnd, common.Big64)
+// lengthPrefixPointsTo interprets an ABI word as an offset and then determines which indices to look to decode the type.
+func lengthPrefixPointsTo(index int, output []byte, minDynamicOffset int) (start int, length int, err error) {
+	offset, err := readDynamicOffset(index, output, minDynamicOffset)
+	if err != nil {
+		return 0, 0, err
+	}
 	outputLength := big.NewInt(int64(len(output)))
 
-	if bigOffsetEnd.Cmp(outputLength) > 0 {
-		return 0, 0, fmt.Errorf("abi: cannot marshal in to go slice: offset %v would go over slice boundary (len=%v)", bigOffsetEnd, outputLength)
+	if offset > len(output)-abiWordBytes {
+		return 0, 0, fmt.Errorf("abi: cannot marshal in to go slice: offset %d would go over slice boundary (len=%v)", offset+abiWordBytes, outputLength)
 	}
 
-	if bigOffsetEnd.BitLen() > 63 {
-		return 0, 0, fmt.Errorf("abi offset larger than int64: %v", bigOffsetEnd)
+	lengthBig := new(big.Int).SetBytes(output[offset : offset+abiWordBytes])
+
+	bigOffsetEnd := new(big.Int).SetInt64(int64(offset))
+	bigOffsetEnd.Add(bigOffsetEnd, big.NewInt(int64(abiWordBytes)))
+	wordBytes := big.NewInt(int64(abiWordBytes))
+	paddedLength := new(big.Int).Set(lengthBig)
+	if remainder := new(big.Int).Mod(paddedLength, wordBytes); remainder.Sign() != 0 {
+		paddedLength.Add(paddedLength, new(big.Int).Sub(wordBytes, remainder))
 	}
-
-	offsetEnd := int(bigOffsetEnd.Uint64())
-	lengthBig := new(big.Int).SetBytes(output[offsetEnd-64 : offsetEnd])
-
-	totalSize := new(big.Int).Add(bigOffsetEnd, lengthBig)
+	totalSize := new(big.Int).Add(bigOffsetEnd, paddedLength)
 	if totalSize.BitLen() > 63 {
 		return 0, 0, fmt.Errorf("abi: length larger than int64: %v", totalSize)
 	}
@@ -322,9 +344,30 @@ func lengthPrefixPointsTo(index int, output []byte) (start int, length int, err 
 	return
 }
 
+func validateDynamicPayloadPadding(output []byte, start, length int) error {
+	paddedLength := length
+	if remainder := paddedLength % abiWordBytes; remainder != 0 {
+		paddedLength += abiWordBytes - remainder
+	}
+	end := start + paddedLength
+	if end > len(output) {
+		return fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), end)
+	}
+	for _, b := range output[start+length : end] {
+		if b != 0 {
+			return fmt.Errorf("abi: non-zero padding byte in dynamic data")
+		}
+	}
+	return nil
+}
+
 // tuplePointsTo resolves the location reference for dynamic tuple.
-func tuplePointsTo(index int, output []byte) (start int, err error) {
-	offset := new(big.Int).SetBytes(output[index : index+64])
+func tuplePointsTo(index int, output []byte, minDynamicOffset int) (start int, err error) {
+	return readDynamicOffset(index, output, minDynamicOffset)
+}
+
+func readDynamicOffset(index int, output []byte, minDynamicOffset int) (int, error) {
+	offset := new(big.Int).SetBytes(output[index : index+abiWordBytes])
 	outputLen := big.NewInt(int64(len(output)))
 
 	if offset.Cmp(outputLen) > 0 {
@@ -333,5 +376,15 @@ func tuplePointsTo(index int, output []byte) (start int, err error) {
 	if offset.BitLen() > 63 {
 		return 0, fmt.Errorf("abi offset larger than int64: %v", offset)
 	}
-	return int(offset.Uint64()), nil
+	offsetInt := int(offset.Uint64())
+	if offsetInt%abiWordBytes != 0 {
+		return 0, fmt.Errorf("abi offset %d is not word-aligned", offsetInt)
+	}
+	if minDynamicOffset < index+abiWordBytes {
+		minDynamicOffset = index + abiWordBytes
+	}
+	if offsetInt < minDynamicOffset {
+		return 0, fmt.Errorf("abi offset %d points into head; minimum dynamic offset is %d", offsetInt, minDynamicOffset)
+	}
+	return offsetInt, nil
 }

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -1093,6 +1093,38 @@ func TestOOMMaliciousInput(t *testing.T) {
 				"0000000000000000000000000000000000000000000000000000000000000001" + // elem 1
 				"0000000000000000000000000000000000000000000000000000000000000002", // elem 2
 		},
+		{ // Dynamic offset points back into the head.
+			def: `[{"type": "string"}]`,
+			enc: abiWord("00"),
+		},
+		{ // Dynamic offsets must be ABI word-aligned.
+			def: `[{"type": "bytes"}]`,
+			enc: abiWord("41") + abiWord("00"),
+		},
+		{ // Dynamic payloads must include padding to the ABI word boundary.
+			def: `[{"type": "bytes"}]`,
+			enc: abiWord("40") + abiWord("41") + strings.Repeat("ff", 65),
+		},
+		{ // Dynamic payload padding must be zero.
+			def: `[{"type": "bytes"}]`,
+			enc: abiWord("40") + abiWord("01") + "ff" + strings.Repeat("00", 62) + "01",
+		},
+		{ // Fixed array dynamic element offsets must not point back into the array head.
+			def: `[{"type": "string[2]"}]`,
+			enc: abiWord("00") + abiWord("00"),
+		},
+		{ // Top-level dynamic offsets must not point into another output head word.
+			def: `[{"type": "string"}, {"type": "string"}]`,
+			enc: abiWord("40") + abiWord("80") + abiWord("00") + abiWord("00"),
+		},
+		{ // Fixed array dynamic element offsets must start after the full array head.
+			def: `[{"type": "string[2]"}]`,
+			enc: abiWord("40") + abiWord("40") + abiWord("00") + abiWord("00"),
+		},
+		{ // Fixed array with dynamic elements must reject full-width malformed offsets.
+			def: `[{"type": "string[2]"}]`,
+			enc: abiWord("010000000000000040"),
+		},
 	}
 	for i, test := range oomTests {
 		def := fmt.Sprintf(`[{ "name" : "method", "type": "function", "outputs": %s}]`, test.def)
@@ -1109,6 +1141,22 @@ func TestOOMMaliciousInput(t *testing.T) {
 			t.Fatalf("Expected error on malicious input, test %d", i)
 		}
 	}
+}
+
+func TestUnpackValuesRejectsUnalignedData(t *testing.T) {
+	t.Parallel()
+
+	def := `[{ "name" : "method", "type": "function", "outputs": [{"type": "uint256"}]}]`
+	abi, err := JSON(strings.NewReader(def))
+	require.NoError(t, err)
+
+	data := append(common.LeftPadBytes([]byte{1}, abiWordBytes), 0)
+	_, err = abi.Methods["method"].Outputs.UnpackValues(data)
+	require.ErrorContains(t, err, "abi: improperly formatted output")
+}
+
+func abiWord(hex string) string {
+	return strings.Repeat("0", abiWordBytes*2-len(hex)) + hex
 }
 
 func TestPackAndUnpackIncompatibleNumber(t *testing.T) {

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -1155,6 +1155,24 @@ func TestUnpackValuesRejectsUnalignedData(t *testing.T) {
 	require.ErrorContains(t, err, "abi: improperly formatted output")
 }
 
+func TestUnpackSliceOfStaticArraysChecksFullElementSize(t *testing.T) {
+	t.Parallel()
+
+	def := `[{ "name" : "method", "type": "function", "outputs": [{"type": "uint256[2][]"}]}]`
+	abi, err := JSON(strings.NewReader(def))
+	require.NoError(t, err)
+
+	enc := abiWord("40") + // offset
+		abiWord("02") + // num elems
+		abiWord("01") + // first array, elem 1
+		abiWord("02") // first array, elem 2
+	encb, err := hex.DecodeString(enc)
+	require.NoError(t, err)
+
+	_, err = abi.Methods["method"].Outputs.UnpackValues(encb)
+	require.ErrorContains(t, err, "cannot marshal into go array")
+}
+
 func abiWord(hex string) string {
 	return strings.Repeat("0", abiWordBytes*2-len(hex)) + hex
 }

--- a/accounts/abi/word.go
+++ b/accounts/abi/word.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The go-QRL Authors
+// This file is part of the go-QRL library.
+//
+// The go-QRL library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package abi
+
+import "github.com/theQRL/go-qrl/common/uint512"
+
+const (
+	abiWordBits  = uint512.WordBits
+	abiWordBytes = uint512.WordBytes
+)

--- a/accounts/abi/word.go
+++ b/accounts/abi/word.go
@@ -10,7 +10,5 @@ package abi
 
 import "github.com/theQRL/go-qrl/common/uint512"
 
-const (
-	abiWordBits  = uint512.WordBits
-	abiWordBytes = uint512.WordBytes
-)
+// abiWordBytes is the width of one ABI slot, matching the VM64 stack word.
+const abiWordBytes = uint512.WordBytes


### PR DESCRIPTION
## Summary
- reject ABI output data whose length is not a full VM64 ABI word
- validate dynamic offsets are 64-byte aligned and point after the current head
- reject truncated dynamic tails and non-zero dynamic payload padding

## Rationale
ABI dynamic values are addressed by byte offsets into the encoded payload. Without validating alignment and head/tail boundaries, malformed return data can be decoded from head words or partial tails. This keeps decoding strict for VM64 ABI words without changing the encoded shape of valid payloads.

## Tests
- `go test -count=1 ./accounts/abi ./accounts/abi/bind`