### PR TITLE
[FIX] Align event signature log topics

### DIFF
--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -202,6 +202,28 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
 }
 
+func TestUnpackLogAcceptsVM64EventSignatureTopic(t *testing.T) {
+	hash := crypto.Keccak256Hash([]byte("testName"))
+	eventID := crypto.Keccak256Hash([]byte("received(string,address,uint256,bytes)"))
+	topics, err := abi.MakeTopics([]any{eventID}, []any{hash})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mockLog := newMockLog([]common.LogTopic{topics[0][0], topics[1][0]}, common.HexToHash("0x0"))
+
+	abiString := `[{"anonymous":false,"inputs":[{"indexed":true,"name":"name","type":"string"},{"indexed":false,"name":"sender","type":"address"},{"indexed":false,"name":"amount","type":"uint256"},{"indexed":false,"name":"memo","type":"bytes"}],"name":"received","type":"event"}]`
+	parsedAbi, _ := abi.JSON(strings.NewReader(abiString))
+	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
+
+	expectedReceivedMap := map[string]any{
+		"name":   common.BytesToLogTopic(hash.Bytes()),
+		"sender": mockSender,
+		"amount": big.NewInt(1),
+		"memo":   []byte{88},
+	}
+	unpackAndCheck(t, bc, expectedReceivedMap, mockLog)
+}
+
 func TestUnpackAnonymousLogIntoMap(t *testing.T) {
 	mockLog := newMockLog(nil, common.HexToHash("0x0"))
 

--- a/common/types.go
+++ b/common/types.go
@@ -235,19 +235,13 @@ func BytesToLogTopic(b []byte) LogTopic {
 }
 
 // BytesToEventSignatureLogTopic copies an event signature hash into a LogTopic,
-// left-aligned.
+// right-aligned.
 //
-// Hyperion emits the 32-byte Keccak event signature hash as the HIGH half of
-// the 64-byte LOG topic after the VM word-size migration, so event selectors use
-// hash || zero-padding instead of the raw-value alignment used by
-// BytesToLogTopic.
+// Hyperion emits the 32-byte Keccak event signature hash as a VM64 stack word.
+// QRVM serializes that word with the hash in the low 32 bytes of the 64-byte
+// LOG topic, matching BytesToLogTopic.
 func BytesToEventSignatureLogTopic(b []byte) LogTopic {
-	var t LogTopic
-	if len(b) > len(t) {
-		b = b[len(b)-LogTopicLength:]
-	}
-	copy(t[:], b)
-	return t
+	return BytesToLogTopic(b)
 }
 
 // HexToLogTopic parses a hex string into a LogTopic.

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -40,6 +40,21 @@ func TestBytesConversion(t *testing.T) {
 	}
 }
 
+func TestBytesToEventSignatureLogTopic(t *testing.T) {
+	hash := bytes.Repeat([]byte{0xab}, HashLength)
+	topic := BytesToEventSignatureLogTopic(hash)
+
+	if !bytes.Equal(topic[:LogTopicLength-HashLength], make([]byte, LogTopicLength-HashLength)) {
+		t.Fatalf("event signature topic has non-zero high bytes: %x", topic[:LogTopicLength-HashLength])
+	}
+	if !bytes.Equal(topic[LogTopicLength-HashLength:], hash) {
+		t.Fatalf("event signature hash mismatch: got %x want %x", topic[LogTopicLength-HashLength:], hash)
+	}
+	if topic != BytesToLogTopic(hash) {
+		t.Fatalf("event signature topic should match VM64 log topic alignment")
+	}
+}
+
 func TestIsAddress(t *testing.T) {
 	tests := []struct {
 		str string


### PR DESCRIPTION
## Summary
- Right-align event signature hashes when converting them into 64-byte log topics.
- Add regression coverage for the topic helper and bound log unpacking with VM64-shaped event topics.

## Rationale
Event IDs are still 32-byte Keccak-256 hashes, but emitted QRVM log topics are 64-byte VM words. When a 32-byte event signature hash is represented as a VM64 stack value, it occupies the low-order bytes of the word and the high-order bytes are zero padding. `LOG*` then serializes that full VM64 word as the log topic.

So topic0 for a non-anonymous event is not `hash || zero-padding`; it is `zero-padding || hash`. That matches the general `BytesToLogTopic`/VM word layout and keeps event signature topics in the same shape as topics emitted by contracts.

Before this PR, `BytesToEventSignatureLogTopic` used the old left-aligned layout, while filter/unpack paths could encounter VM64-shaped topics. That made bound log unpacking vulnerable to rejecting the real topic shape used by emitted logs.

This keeps the PR focused on event signature topic alignment. Broader ABI, binding, and RPC/web3 VM64 work remains for follow-up PRs.

## Tests
- `go test -count=1 ./common ./accounts/abi/bind`
- `go test -count=1 ./...`
