### PR TITLE
[FIX] Encode ABI big.Int topics as full VM64 words

### DIFF
--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -44,8 +44,7 @@ func MakeTopics(query ...[]any) ([][]common.LogTopic, error) {
 			case common.Address:
 				copy(topic[common.LogTopicLength-common.AddressLength:], rule[:])
 			case *big.Int:
-				blob := math.U256Bytes(new(big.Int).Set(rule))
-				copy(topic[common.LogTopicLength-len(blob):], blob)
+				copy(topic[:], math.U512Bytes(new(big.Int).Set(rule)))
 			case bool:
 				if rule {
 					topic[common.LogTopicLength-1] = 1

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -36,13 +36,12 @@ func TestMakeTopics(t *testing.T) {
 	intTopic := func(v int64) common.LogTopic {
 		var t common.LogTopic
 		bi := new(big.Int).SetInt64(v)
-		data := math.U256Bytes(bi) // 32-byte big-endian two's complement
-		if v < 0 {
-			for i := 0; i < common.LogTopicLength-len(data); i++ {
-				t[i] = 0xff
-			}
-		}
-		copy(t[common.LogTopicLength-len(data):], data)
+		copy(t[:], math.U512Bytes(bi))
+		return t
+	}
+	bigTopic := func(v *big.Int) common.LogTopic {
+		var t common.LogTopic
+		copy(t[:], math.U512Bytes(new(big.Int).Set(v)))
 		return t
 	}
 	uintTopic := func(v uint64) common.LogTopic {
@@ -98,6 +97,7 @@ func TestMakeTopics(t *testing.T) {
 			args{[][]any{
 				{big.NewInt(1)},
 				{new(big.Int).Lsh(big.NewInt(2), 254)},
+				{new(big.Int).Lsh(big.NewInt(1), 511)},
 			}},
 			[][]common.LogTopic{
 				{uintTopic(1)},
@@ -106,6 +106,12 @@ func TestMakeTopics(t *testing.T) {
 				{func() common.LogTopic {
 					var t common.LogTopic
 					t[common.LogTopicLength-common.HashLength] = 0x80
+					return t
+				}()},
+				// 2^511 uses the high bit of the full 64-byte VM64 topic.
+				{func() common.LogTopic {
+					var t common.LogTopic
+					t[0] = 0x80
 					return t
 				}()},
 			},
@@ -118,20 +124,8 @@ func TestMakeTopics(t *testing.T) {
 				{big.NewInt(gomath.MinInt64)},
 			}},
 			[][]common.LogTopic{
-				// MakeTopics encodes via math.U256Bytes, which left-pads to
-				// 32 bytes; so -1 lands as 0xff*32 in the low half with the
-				// upper half zero.
-				{func() common.LogTopic {
-					var t common.LogTopic
-					for i := common.LogTopicLength - common.HashLength; i < common.LogTopicLength; i++ {
-						t[i] = 0xff
-					}
-					return t
-				}()},
-				{func() common.LogTopic {
-					t := common.HexToLogTopic("ffffffffffffffffffffffffffffffffffffffffffffffff8000000000000000")
-					return t
-				}()},
+				{bigTopic(big.NewInt(-1))},
+				{bigTopic(big.NewInt(gomath.MinInt64))},
 			},
 			false,
 		},
@@ -209,13 +203,9 @@ func TestMakeTopics(t *testing.T) {
 
 	t.Run("does not mutate big.Int", func(t *testing.T) {
 		t.Parallel()
-		// -1 big.Int uses math.U256Bytes → 32-byte sign-extended form that
-		// lands in the low 32 bytes of the topic slot.
 		want := [][]common.LogTopic{{func() common.LogTopic {
 			var t common.LogTopic
-			for i := common.LogTopicLength - common.HashLength; i < common.LogTopicLength; i++ {
-				t[i] = 0xff
-			}
+			copy(t[:], math.U512Bytes(big.NewInt(-1)))
 			return t
 		}()}}
 

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -46,9 +46,7 @@ func TestMakeTopics(t *testing.T) {
 	}
 	uintTopic := func(v uint64) common.LogTopic {
 		var t common.LogTopic
-		bi := new(big.Int).SetUint64(v)
-		blob := bi.Bytes()
-		copy(t[common.LogTopicLength-len(blob):], blob)
+		copy(t[:], math.U512Bytes(new(big.Int).SetUint64(v)))
 		return t
 	}
 


### PR DESCRIPTION
## Summary
- Encode `*big.Int` values in `abi.MakeTopics` as full 64-byte VM64 topics.
- Add coverage for positive values above 256 bits and full-width negative sign extension.
- Keep the input `big.Int` copy so topic generation does not mutate caller values.

## Rationale
`common.LogTopic` is 64 bytes, and indexed ABI integer filters need to preserve the full VM64 word. Primitive signed integer topic paths already sign-extend across the full topic width, but the `*big.Int` path still used `math.U256Bytes`, which narrowed values to 256 bits before right-aligning them in the 64-byte topic.

That could make filters miss indexed `uint512` / `int512` values or any indexed integer value requiring the high half of the VM64 topic.

## Tests
- `go test -count=1 ./accounts/abi`
- `go test -count=1 ./...`