### PR TITLE
[FIX] Left-align hash-derived log topics

### DIFF
--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -1377,15 +1377,17 @@ const callableAbi = "[{\"anonymous\":false,\"inputs\":[],\"name\":\"Called\",\"t
 
 // Hand-rolled replacement for the Solidity fixture above. The original
 // bytecode depended on LOG/DUP/SWAP opcodes that shifted when the VM
-// widened to 512-bit words. 12-byte init copies a 58-byte runtime that
+// widened to 512-bit words. 12-byte init copies a 62-byte runtime that
 //   - reads calldata[0:4] (shifted in from the 64-byte CALLDATALOAD word),
 //   - dispatches on selector 0x34e22921 (keccak256("Call()")[:4]),
-//   - and, on match, emits LOG1 with topic0 = keccak256("Called()"),
-//     so contract.WatchLogs(nil, "Called") still resolves the event.
-const callableBin = "603a600c600039603a6000f36000356101e01c63" +
+//   - and, on match, emits LOG1 with topic0 = keccak256("Called()") << 256,
+//     left-aligning the hash in the 64-byte topic like Hyperion's bytes32
+//     event-signature layout, so contract.WatchLogs(nil, "Called") resolves
+//     the event.
+const callableBin = "603e600c600039603e6000f36000356101e01c63" +
 	"34e22921146100125700" +
 	"5b7f81fab7a4a0aa961db47eefc81f143a5220e8c8495260dd65b1356f1d19d3c7b8" +
-	"60006000c100"
+	"6101001b60006000c100"
 
 // TestForkLogsReborn check that the simulated reorgs
 // correctly remove and reborn logs.

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -443,7 +443,7 @@ func (c *BoundContract) UnpackLog(out any, event string, log types.Log) error {
 	if len(log.Topics) == 0 {
 		return errNoEventSignature
 	}
-	if log.Topics[0] != common.BytesToEventSignatureLogTopic(c.abi.Events[event].ID.Bytes()) {
+	if log.Topics[0] != common.HashToLogTopic(c.abi.Events[event].ID) {
 		return errEventSignatureMismatch
 	}
 	if len(log.Data) > 0 {
@@ -466,7 +466,7 @@ func (c *BoundContract) UnpackLogIntoMap(out map[string]any, event string, log t
 	if len(log.Topics) == 0 {
 		return errNoEventSignature
 	}
-	if log.Topics[0] != common.BytesToEventSignatureLogTopic(c.abi.Events[event].ID.Bytes()) {
+	if log.Topics[0] != common.HashToLogTopic(c.abi.Events[event].ID) {
 		return errEventSignatureMismatch
 	}
 	if len(log.Data) > 0 {

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -172,6 +172,14 @@ var mockSender = func() common.Address {
 	return common.BytesToAddress(raw)
 }()
 
+// hashTopic left-aligns a 32-byte Keccak hash in a 64-byte log topic, the
+// shape QRVM logs use for hashes of indexed dynamic values (ABI bytes32).
+func hashTopic(hash []byte) common.LogTopic {
+	var t common.LogTopic
+	copy(t[:common.HashLength], hash)
+	return t
+}
+
 // hexData is the ABI-encoded non-indexed payload (address, uint256, bytes) =
 // (mockSender, 1, [88]) as produced by abi.Pack with a 64-byte slot width.
 var hexData = func() []byte {
@@ -185,7 +193,7 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	hash := crypto.Keccak256Hash([]byte("testName"))
 	topics := []common.LogTopic{
 		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(string,address,uint256,bytes)"))),
-		common.BytesToLogTopic(hash.Bytes()),
+		hashTopic(hash.Bytes()),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x0"))
 
@@ -194,7 +202,7 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"name":   common.BytesToLogTopic(hash.Bytes()),
+		"name":   hashTopic(hash.Bytes()),
 		"sender": mockSender,
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},
@@ -228,7 +236,7 @@ func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
 	hash := crypto.Keccak256Hash(sliceBytes)
 	topics := []common.LogTopic{
 		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(string[],address,uint256,bytes)"))),
-		common.BytesToLogTopic(hash.Bytes()),
+		hashTopic(hash.Bytes()),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x0"))
 
@@ -237,7 +245,7 @@ func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"names":  common.BytesToLogTopic(hash.Bytes()),
+		"names":  hashTopic(hash.Bytes()),
 		"sender": mockSender,
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},
@@ -255,7 +263,7 @@ func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
 	hash := crypto.Keccak256Hash(arrBytes)
 	topics := []common.LogTopic{
 		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(address[2],address,uint256,bytes)"))),
-		common.BytesToLogTopic(hash.Bytes()),
+		hashTopic(hash.Bytes()),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x0"))
 
@@ -264,7 +272,7 @@ func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"addresses": common.BytesToLogTopic(hash.Bytes()),
+		"addresses": hashTopic(hash.Bytes()),
 		"sender":    mockSender,
 		"amount":    big.NewInt(1),
 		"memo":      []byte{88},
@@ -301,7 +309,7 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 	hash := crypto.Keccak256Hash(bytes)
 	topics := []common.LogTopic{
 		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(bytes,address,uint256,bytes)"))),
-		common.BytesToLogTopic(hash.Bytes()),
+		hashTopic(hash.Bytes()),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x5c698f13940a2153440c6d19660878bc90219d9298fdcf37365aa8d88d40fc42"))
 
@@ -310,7 +318,7 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"content": common.BytesToLogTopic(hash.Bytes()),
+		"content": hashTopic(hash.Bytes()),
 		"sender":  mockSender,
 		"amount":  big.NewInt(1),
 		"memo":    []byte{88},

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -172,14 +172,6 @@ var mockSender = func() common.Address {
 	return common.BytesToAddress(raw)
 }()
 
-// hashTopic left-aligns a 32-byte Keccak hash in a 64-byte log topic, the
-// shape QRVM logs use for hashes of indexed dynamic values (ABI bytes32).
-func hashTopic(hash []byte) common.LogTopic {
-	var t common.LogTopic
-	copy(t[:common.HashLength], hash)
-	return t
-}
-
 // hexData is the ABI-encoded non-indexed payload (address, uint256, bytes) =
 // (mockSender, 1, [88]) as produced by abi.Pack with a 64-byte slot width.
 var hexData = func() []byte {
@@ -192,8 +184,8 @@ var hexData = func() []byte {
 func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	hash := crypto.Keccak256Hash([]byte("testName"))
 	topics := []common.LogTopic{
-		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(string,address,uint256,bytes)"))),
-		hashTopic(hash.Bytes()),
+		common.HashToLogTopic(crypto.Keccak256Hash([]byte("received(string,address,uint256,bytes)"))),
+		common.HashToLogTopic(hash),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x0"))
 
@@ -202,7 +194,7 @@ func TestUnpackIndexedStringTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"name":   hashTopic(hash.Bytes()),
+		"name":   common.HashToLogTopic(hash),
 		"sender": mockSender,
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},
@@ -235,8 +227,8 @@ func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
 	}
 	hash := crypto.Keccak256Hash(sliceBytes)
 	topics := []common.LogTopic{
-		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(string[],address,uint256,bytes)"))),
-		hashTopic(hash.Bytes()),
+		common.HashToLogTopic(crypto.Keccak256Hash([]byte("received(string[],address,uint256,bytes)"))),
+		common.HashToLogTopic(hash),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x0"))
 
@@ -245,7 +237,7 @@ func TestUnpackIndexedSliceTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"names":  hashTopic(hash.Bytes()),
+		"names":  common.HashToLogTopic(hash),
 		"sender": mockSender,
 		"amount": big.NewInt(1),
 		"memo":   []byte{88},
@@ -262,8 +254,8 @@ func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
 	}
 	hash := crypto.Keccak256Hash(arrBytes)
 	topics := []common.LogTopic{
-		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(address[2],address,uint256,bytes)"))),
-		hashTopic(hash.Bytes()),
+		common.HashToLogTopic(crypto.Keccak256Hash([]byte("received(address[2],address,uint256,bytes)"))),
+		common.HashToLogTopic(hash),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x0"))
 
@@ -272,7 +264,7 @@ func TestUnpackIndexedArrayTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"addresses": hashTopic(hash.Bytes()),
+		"addresses": common.HashToLogTopic(hash),
 		"sender":    mockSender,
 		"amount":    big.NewInt(1),
 		"memo":      []byte{88},
@@ -286,7 +278,7 @@ func TestUnpackIndexedFuncTyLogIntoMap(t *testing.T) {
 	functionSelector := hash[:4]
 	functionTyBytes := append(addrBytes, functionSelector...)
 	topics := []common.LogTopic{
-		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(function,address,uint256,bytes)"))),
+		common.HashToLogTopic(crypto.Keccak256Hash([]byte("received(function,address,uint256,bytes)"))),
 		common.BytesToLogTopic(functionTyBytes),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x5c698f13940a2153440c6d19660878bc90219d9298fdcf37365aa8d88d40fc42"))
@@ -308,8 +300,8 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 	bytes := []byte{1, 2, 3, 4, 5}
 	hash := crypto.Keccak256Hash(bytes)
 	topics := []common.LogTopic{
-		common.BytesToEventSignatureLogTopic(crypto.Keccak256([]byte("received(bytes,address,uint256,bytes)"))),
-		hashTopic(hash.Bytes()),
+		common.HashToLogTopic(crypto.Keccak256Hash([]byte("received(bytes,address,uint256,bytes)"))),
+		common.HashToLogTopic(hash),
 	}
 	mockLog := newMockLog(topics, common.HexToHash("0x5c698f13940a2153440c6d19660878bc90219d9298fdcf37365aa8d88d40fc42"))
 
@@ -318,7 +310,7 @@ func TestUnpackIndexedBytesTyLogIntoMap(t *testing.T) {
 	bc := bind.NewBoundContract(common.Address{}, parsedAbi, nil, nil, nil)
 
 	expectedReceivedMap := map[string]any{
-		"content": hashTopic(hash.Bytes()),
+		"content": common.HashToLogTopic(hash),
 		"sender":  mockSender,
 		"amount":  big.NewInt(1),
 		"memo":    []byte{88},

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -41,7 +41,7 @@ func MakeTopics(query ...[]any) ([][]common.LogTopic, error) {
 			case common.LogTopic:
 				copy(topic[:], rule[:])
 			case common.Hash:
-				copy(topic[:common.HashLength], rule[:])
+				topic = common.HashToLogTopic(rule)
 			case common.Address:
 				copy(topic[:], rule[:])
 			case *big.Int:
@@ -72,11 +72,9 @@ func MakeTopics(query ...[]any) ([][]common.LogTopic, error) {
 				blob := new(big.Int).SetUint64(rule).Bytes()
 				copy(topic[common.LogTopicLength-len(blob):], blob)
 			case string:
-				hash := crypto.Keccak256Hash([]byte(rule))
-				copy(topic[:common.HashLength], hash[:])
+				topic = common.HashToLogTopic(crypto.Keccak256Hash([]byte(rule)))
 			case []byte:
-				hash := crypto.Keccak256Hash(rule)
-				copy(topic[:common.HashLength], hash[:])
+				topic = common.HashToLogTopic(crypto.Keccak256Hash(rule))
 
 			default:
 				// todo(rjl493456442) according to hyperion documentation, indexed event

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -28,7 +28,8 @@ import (
 )
 
 // MakeTopics converts a filter query argument list into a filter topic set.
-// Topics are 64-byte values; scalar arguments are right-aligned (big-endian).
+// Topics are 64-byte ABI slots: numeric values are right-aligned, while
+// fixed bytes and Keccak hash topics are left-aligned like ABI bytes32 values.
 func MakeTopics(query ...[]any) ([][]common.LogTopic, error) {
 	topics := make([][]common.LogTopic, len(query))
 	for i, filter := range query {
@@ -40,7 +41,7 @@ func MakeTopics(query ...[]any) ([][]common.LogTopic, error) {
 			case common.LogTopic:
 				copy(topic[:], rule[:])
 			case common.Hash:
-				copy(topic[common.LogTopicLength-common.HashLength:], rule[:])
+				copy(topic[:common.HashLength], rule[:])
 			case common.Address:
 				copy(topic[common.LogTopicLength-common.AddressLength:], rule[:])
 			case *big.Int:
@@ -72,10 +73,10 @@ func MakeTopics(query ...[]any) ([][]common.LogTopic, error) {
 				copy(topic[common.LogTopicLength-len(blob):], blob)
 			case string:
 				hash := crypto.Keccak256Hash([]byte(rule))
-				copy(topic[common.LogTopicLength-common.HashLength:], hash[:])
+				copy(topic[:common.HashLength], hash[:])
 			case []byte:
 				hash := crypto.Keccak256Hash(rule)
-				copy(topic[common.LogTopicLength-common.HashLength:], hash[:])
+				copy(topic[:common.HashLength], hash[:])
 
 			default:
 				// todo(rjl493456442) according to hyperion documentation, indexed event

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -43,7 +43,7 @@ func MakeTopics(query ...[]any) ([][]common.LogTopic, error) {
 			case common.Hash:
 				copy(topic[:common.HashLength], rule[:])
 			case common.Address:
-				copy(topic[common.LogTopicLength-common.AddressLength:], rule[:])
+				copy(topic[:], rule[:])
 			case *big.Int:
 				blob := math.U256Bytes(new(big.Int).Set(rule))
 				copy(topic[common.LogTopicLength-len(blob):], blob)

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -52,6 +52,11 @@ func TestMakeTopics(t *testing.T) {
 		copy(t[common.LogTopicLength-len(blob):], blob)
 		return t
 	}
+	hashTopic := func(hash []byte) common.LogTopic {
+		var t common.LogTopic
+		copy(t[:common.HashLength], hash)
+		return t
+	}
 
 	type args struct {
 		query [][]any
@@ -71,13 +76,11 @@ func TestMakeTopics(t *testing.T) {
 		{
 			"support common hash types in topics",
 			args{[][]any{{common.Hash{1, 2, 3, 4, 5}}}},
-			// Hash right-aligned in the 64-byte slot: low 32 bytes hold the
-			// hash, upper 32 are zero.
+			// Hash topics are ABI bytes32 values: high 32 bytes hold the
+			// hash, low 32 bytes are zero padding.
 			[][]common.LogTopic{{func() common.LogTopic {
-				var t common.LogTopic
 				h := common.Hash{1, 2, 3, 4, 5}
-				copy(t[common.LogTopicLength-common.HashLength:], h[:])
-				return t
+				return hashTopic(h[:])
 			}()}},
 			false,
 		},
@@ -182,14 +185,14 @@ func TestMakeTopics(t *testing.T) {
 		{
 			"support string types in topics",
 			args{[][]any{{"hello world"}}},
-			// Keccak256 hash right-aligned in the slot (low 32 bytes).
-			[][]common.LogTopic{{common.BytesToLogTopic(crypto.Keccak256([]byte("hello world")))}},
+			// Indexed dynamic values store the Keccak256 hash as ABI bytes32.
+			[][]common.LogTopic{{hashTopic(crypto.Keccak256([]byte("hello world")))}},
 			false,
 		},
 		{
 			"support byte slice types in topics",
 			args{[][]any{{[]byte{1, 2, 3}}}},
-			[][]common.LogTopic{{common.BytesToLogTopic(crypto.Keccak256([]byte{1, 2, 3}))}},
+			[][]common.LogTopic{{hashTopic(crypto.Keccak256([]byte{1, 2, 3}))}},
 			false,
 		},
 	}
@@ -288,6 +291,11 @@ func setupTopicsTests() []topicTest {
 	tupleType, _ := NewType("tuple(int256,int8)", "", nil)
 	stringType, _ := NewType("string", "", nil)
 	funcType, _ := NewType("function", "", nil)
+	hashTopic := func(hash []byte) common.LogTopic {
+		var t common.LogTopic
+		copy(t[:common.HashLength], hash)
+		return t
+	}
 
 	tests := []topicTest{
 		{
@@ -349,10 +357,10 @@ func setupTopicsTests() []topicTest {
 			args: args{
 				createObj: func() any { return &hashStruct{} },
 				resultObj: func() any {
-					return &hashStruct{common.BytesToLogTopic(crypto.Keccak256([]byte("stringtopic")))}
+					return &hashStruct{hashTopic(crypto.Keccak256([]byte("stringtopic")))}
 				},
 				resultMap: func() map[string]any {
-					return map[string]any{"hashValue": common.BytesToLogTopic(crypto.Keccak256([]byte("stringtopic")))}
+					return map[string]any{"hashValue": hashTopic(crypto.Keccak256([]byte("stringtopic")))}
 				},
 				fields: Arguments{Argument{
 					Name:    "hashValue",
@@ -360,7 +368,7 @@ func setupTopicsTests() []topicTest {
 					Indexed: true,
 				}},
 				topics: []common.LogTopic{
-					common.BytesToLogTopic(crypto.Keccak256([]byte("stringtopic"))),
+					hashTopic(crypto.Keccak256([]byte("stringtopic"))),
 				},
 			},
 			wantErr: false,

--- a/common/types.go
+++ b/common/types.go
@@ -228,25 +228,26 @@ type LogTopic [LogTopicLength]byte
 // via Bytes64(). A value of N bytes sits in the LOW N bytes of that big-endian
 // encoding — the high (LogTopicLength-N) bytes are zero padding. Mirroring that
 // layout here keeps raw topic values comparable to on-chain topics.
+//
+// Note this is the layout of numeric topic values only. Keccak hashes used as
+// topics (event signatures, hashes of indexed dynamic values) are bytes32
+// values and live in the HIGH bytes of the topic — use HashToLogTopic for
+// those.
 func BytesToLogTopic(b []byte) LogTopic {
 	var t LogTopic
 	t.SetBytes(b)
 	return t
 }
 
-// BytesToEventSignatureLogTopic copies an event signature hash into a LogTopic,
-// left-aligned.
+// HashToLogTopic left-aligns a 32-byte hash in a LogTopic (hash || zero-padding).
 //
-// Hyperion emits the 32-byte Keccak event signature hash as the HIGH half of
-// the 64-byte LOG topic after the VM word-size migration, so event selectors use
-// hash || zero-padding instead of the raw-value alignment used by
-// BytesToLogTopic.
-func BytesToEventSignatureLogTopic(b []byte) LogTopic {
+// Hyperion treats Keccak hashes as bytes32 values, which occupy the high bytes
+// of the 64-byte VM word: event signature hashes and hashes of indexed dynamic
+// values are pushed left-shifted before LOG serializes the word. Use this for
+// any hash-derived topic; raw numeric topics use BytesToLogTopic.
+func HashToLogTopic(h Hash) LogTopic {
 	var t LogTopic
-	if len(b) > len(t) {
-		b = b[len(b)-LogTopicLength:]
-	}
-	copy(t[:], b)
+	copy(t[:HashLength], h[:])
 	return t
 }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -40,6 +40,26 @@ func TestBytesConversion(t *testing.T) {
 	}
 }
 
+func TestHashToLogTopic(t *testing.T) {
+	var hash Hash
+	for i := range hash {
+		hash[i] = byte(i + 1)
+	}
+	topic := HashToLogTopic(hash)
+
+	// The hash occupies the high 32 bytes; the low 32 bytes are zero padding.
+	for i := 0; i < HashLength; i++ {
+		if topic[i] != hash[i] {
+			t.Fatalf("byte %d: expected %x got %x", i, hash[i], topic[i])
+		}
+	}
+	for i := HashLength; i < LogTopicLength; i++ {
+		if topic[i] != 0 {
+			t.Fatalf("byte %d: expected zero padding, got %x", i, topic[i])
+		}
+	}
+}
+
 func TestIsAddress(t *testing.T) {
 	tests := []struct {
 		str string


### PR DESCRIPTION
## Summary
- Left-align hash-derived topics in `abi.MakeTopics`: `common.Hash` rules and the Keccak hashes of indexed `string`/`[]byte` values are now encoded as ABI bytes32 (`hash || zero-padding`). Numeric, address, and bool rules stay right-aligned; `common.LogTopic` inputs are still copied verbatim.
- Consolidate the two hash-topic helpers: replace `common.BytesToEventSignatureLogTopic` with `common.HashToLogTopic(common.Hash)` and use it everywhere a hash becomes a topic (the `UnpackLog`/`UnpackLogIntoMap` event signature gate, `MakeTopics`, tests), with a cross-reference on `BytesToLogTopic` so the raw right-aligned conversion is not mistakenly used for hashes.
- Fix the `callableBin` fixture in the simulated backend to emit topic0 left-aligned (`PUSH2 0x0100; SHL` before `LOG1`, runtime 58 → 62 bytes). It previously emitted the pre-migration right-aligned shape, which made `TestForkLogsReborn` block forever on its `WatchLogs` subscription once the filter side used the new layout.
- Migrate the bind mock-log fixtures for indexed string/slice/array/bytes topics to the left-aligned hash layout so the tests model the topic shape real chain logs use.

## Rationale
Hyperion treats Keccak hashes as `bytes32` values, which occupy the high bytes of the 64-byte VM word. Both codegen paths left-align hash topics — topic0 is pushed as `u512(keccak256(sig)) << (VMWordBits - 256)` and hashes of indexed reference types go through `leftAlignHash(keccak256(...))` — and QRVM `LOG*` serializes the stack word verbatim. Numeric values remain right-aligned.

Before this PR the two off-chain paths disagreed with each other and with the chain: `MakeTopics` right-aligned all hash rules, so `FilterLogs`/`WatchLogs` built topic filters that could never match emitted logs, while the `UnpackLog` topic0 check used the left-aligned layout. `TestForkLogsReborn` passing end-to-end (deploy → emit → filter match → reorg → reborn) now exercises the emit/filter agreement against actual VM execution.

## Tests
- `go test -count=1 ./common ./accounts/abi/... ./qrl/filters`