### PR TITLE
[FIX] Enforce declared ABI integer bounds

### DIFF
--- a/accounts/abi/error_handling.go
+++ b/accounts/abi/error_handling.go
@@ -28,12 +28,48 @@ var (
 	errBadUint16   = errors.New("abi: improperly encoded uint16 value")
 	errBadUint32   = errors.New("abi: improperly encoded uint32 value")
 	errBadUint64   = errors.New("abi: improperly encoded uint64 value")
+	errBadUint256  = errors.New("abi: improperly encoded uint256 value")
 	errBadInt8     = errors.New("abi: improperly encoded int8 value")
 	errBadInt16    = errors.New("abi: improperly encoded int16 value")
 	errBadInt32    = errors.New("abi: improperly encoded int32 value")
 	errBadInt64    = errors.New("abi: improperly encoded int64 value")
+	errBadInt256   = errors.New("abi: improperly encoded int256 value")
 	errInvalidSign = errors.New("abi: negatively-signed value cannot be packed into uint parameter")
 )
+
+func errBadUint(size int) error {
+	switch size {
+	case 8:
+		return errBadUint8
+	case 16:
+		return errBadUint16
+	case 32:
+		return errBadUint32
+	case 64:
+		return errBadUint64
+	case 256:
+		return errBadUint256
+	default:
+		return fmt.Errorf("abi: improperly encoded uint%d value", size)
+	}
+}
+
+func errBadInt(size int) error {
+	switch size {
+	case 8:
+		return errBadInt8
+	case 16:
+		return errBadInt16
+	case 32:
+		return errBadInt32
+	case 64:
+		return errBadInt64
+	case 256:
+		return errBadInt256
+	default:
+		return fmt.Errorf("abi: improperly encoded int%d value", size)
+	}
+}
 
 // formatSliceString formats the reflection kind with the given slice size
 // and returns a formatted string representation.

--- a/accounts/abi/integer_bounds.go
+++ b/accounts/abi/integer_bounds.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The go-qrl Authors
+// This file is part of the go-qrl library.
+//
+// The go-qrl library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package abi
+
+import (
+	"math/big"
+
+	"github.com/theQRL/go-qrl/common"
+	"github.com/theQRL/go-qrl/common/uint512"
+)
+
+// validIntegerSize bounds the declared width to one ABI word. Widths that are
+// not multiples of 8 are still accepted here: the type parser is the place to
+// reject those, and it currently allows them (inherited from go-ethereum).
+func validIntegerSize(size int) bool {
+	return size >= 1 && size <= uint512.WordBits
+}
+
+func maxUnsignedInteger(size int) *big.Int {
+	switch size {
+	case 256:
+		return new(big.Int).Set(MaxUint256)
+	case uint512.WordBits:
+		return new(big.Int).Set(MaxUint512)
+	default:
+		return new(big.Int).Sub(new(big.Int).Lsh(common.Big1, uint(size)), common.Big1)
+	}
+}
+
+func maxSignedInteger(size int) *big.Int {
+	switch size {
+	case 256:
+		return new(big.Int).Set(MaxInt256)
+	default:
+		return new(big.Int).Sub(new(big.Int).Lsh(common.Big1, uint(size-1)), common.Big1)
+	}
+}
+
+func minSignedInteger(size int) *big.Int {
+	return new(big.Int).Neg(new(big.Int).Lsh(common.Big1, uint(size-1)))
+}
+
+func fitsUnsignedInteger(value *big.Int, size int) bool {
+	return validIntegerSize(size) && value.Sign() >= 0 && value.Cmp(maxUnsignedInteger(size)) <= 0
+}
+
+func fitsSignedInteger(value *big.Int, size int) bool {
+	if !validIntegerSize(size) {
+		return false
+	}
+	return value.Cmp(minSignedInteger(size)) >= 0 && value.Cmp(maxSignedInteger(size)) <= 0
+}

--- a/accounts/abi/pack.go
+++ b/accounts/abi/pack.go
@@ -38,16 +38,21 @@ func packBytesSlice(bytes []byte, l int) []byte {
 func packElement(t Type, reflectValue reflect.Value) ([]byte, error) {
 	switch t.T {
 	case UintTy:
+		val := packNumValue(reflectValue)
 		// make sure to not pack a negative value into a uint type.
-		if reflectValue.Kind() == reflect.Ptr {
-			val := new(big.Int).Set(reflectValue.Interface().(*big.Int))
-			if val.Sign() == -1 {
-				return nil, errInvalidSign
-			}
+		if val.Sign() == -1 {
+			return nil, errInvalidSign
 		}
-		return packNum(reflectValue), nil
+		if !fitsUnsignedInteger(val, t.Size) {
+			return nil, errBadUint(t.Size)
+		}
+		return math.U512Bytes(val), nil
 	case IntTy:
-		return packNum(reflectValue), nil
+		val := packNumValue(reflectValue)
+		if !fitsSignedInteger(val, t.Size) {
+			return nil, errBadInt(t.Size)
+		}
+		return math.U512Bytes(val), nil
 	case StringTy:
 		return packBytesSlice([]byte(reflectValue.String()), reflectValue.Len()), nil
 	case AddressTy:
@@ -82,16 +87,22 @@ func packElement(t Type, reflectValue reflect.Value) ([]byte, error) {
 	}
 }
 
-// packNum packs the given number (using the reflect value) and will cast it to appropriate number representation.
-func packNum(value reflect.Value) []byte {
+// packNumValue extracts the numeric value behind the given reflect value as a
+// big integer.
+func packNumValue(value reflect.Value) *big.Int {
 	switch kind := value.Kind(); kind {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return math.U512Bytes(new(big.Int).SetUint64(value.Uint()))
+		return new(big.Int).SetUint64(value.Uint())
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return math.U512Bytes(big.NewInt(value.Int()))
+		return big.NewInt(value.Int())
 	case reflect.Ptr:
-		return math.U512Bytes(new(big.Int).Set(value.Interface().(*big.Int)))
+		return new(big.Int).Set(value.Interface().(*big.Int))
 	default:
 		panic("abi: fatal error")
 	}
+}
+
+// packNum packs the given number (using the reflect value) and will cast it to appropriate number representation.
+func packNum(value reflect.Value) []byte {
+	return math.U512Bytes(packNumValue(value))
 }

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -64,7 +64,9 @@ func ReadInteger(typ Type, b []byte) (any, error) {
 			}
 			return u64, nil
 		default:
-			// the only case left for unsigned integer is uint256.
+			if !fitsUnsignedInteger(ret, typ.Size) {
+				return nil, errBadUint(typ.Size)
+			}
 			return ret, nil
 		}
 	}
@@ -100,8 +102,9 @@ func ReadInteger(typ Type, b []byte) (any, error) {
 		}
 		return i64, nil
 	default:
-		// the only case left for integer is int256
-
+		if !fitsSignedInteger(ret, typ.Size) {
+			return nil, errBadInt(typ.Size)
+		}
 		return ret, nil
 	}
 }

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/theQRL/go-qrl/common"
+	qmath "github.com/theQRL/go-qrl/common/math"
+	"github.com/theQRL/go-qrl/common/uint512"
 )
 
 func BenchmarkUnpack(b *testing.B) {
@@ -1109,6 +1111,79 @@ func TestOOMMaliciousInput(t *testing.T) {
 			t.Fatalf("Expected error on malicious input, test %d", i)
 		}
 	}
+}
+
+func TestPackAndUnpackDeclaredIntegerBounds(t *testing.T) {
+	t.Parallel()
+
+	mustType := func(name string) Type {
+		t.Helper()
+		typ, err := NewType(name, "", nil)
+		require.NoError(t, err)
+		return typ
+	}
+	args := func(name string) Arguments {
+		return Arguments{{Type: mustType(name)}}
+	}
+	word := func(n *big.Int) []byte {
+		return qmath.U512Bytes(new(big.Int).Set(n))
+	}
+
+	uint256Args := args("uint256")
+	uint256Overflow := new(big.Int).Lsh(common.Big1, 256)
+	_, err := uint256Args.Pack(uint256Overflow)
+	require.ErrorIs(t, err, errBadUint256)
+	_, err = uint256Args.Unpack(word(uint256Overflow))
+	require.ErrorIs(t, err, errBadUint256)
+
+	uint512Args := args("uint512")
+	maxUint512 := new(big.Int).Sub(new(big.Int).Lsh(common.Big1, uint512.WordBits), common.Big1)
+	packed, err := uint512Args.Pack(maxUint512)
+	require.NoError(t, err)
+	decoded, err := uint512Args.Unpack(packed)
+	require.NoError(t, err)
+	require.Zero(t, decoded[0].(*big.Int).Cmp(maxUint512))
+	_, err = uint512Args.Pack(new(big.Int).Add(maxUint512, common.Big1))
+	require.ErrorContains(t, err, "uint512")
+
+	int256Args := args("int256")
+	int256Overflow := new(big.Int).Lsh(common.Big1, 255)
+	int256Underflow := new(big.Int).Neg(new(big.Int).Add(new(big.Int).Lsh(common.Big1, 255), common.Big1))
+	_, err = int256Args.Pack(int256Overflow)
+	require.ErrorIs(t, err, errBadInt256)
+	_, err = int256Args.Unpack(word(int256Overflow))
+	require.ErrorIs(t, err, errBadInt256)
+	_, err = int256Args.Pack(int256Underflow)
+	require.ErrorIs(t, err, errBadInt256)
+	_, err = int256Args.Unpack(word(int256Underflow))
+	require.ErrorIs(t, err, errBadInt256)
+
+	int512Args := args("int512")
+	maxInt512 := new(big.Int).Sub(new(big.Int).Lsh(common.Big1, uint512.WordBits-1), common.Big1)
+	minInt512 := new(big.Int).Neg(new(big.Int).Lsh(common.Big1, uint512.WordBits-1))
+	_, err = int512Args.Pack(new(big.Int).Add(maxInt512, common.Big1))
+	require.ErrorContains(t, err, "int512")
+	_, err = int512Args.Pack(new(big.Int).Sub(minInt512, common.Big1))
+	require.ErrorContains(t, err, "int512")
+	for _, value := range []*big.Int{maxInt512, minInt512} {
+		packed, err = int512Args.Pack(value)
+		require.NoError(t, err)
+		decoded, err = int512Args.Unpack(packed)
+		require.NoError(t, err)
+		require.Zero(t, decoded[0].(*big.Int).Cmp(value))
+	}
+
+	uint264Args := args("uint264")
+	maxUint264 := new(big.Int).Sub(new(big.Int).Lsh(common.Big1, 264), common.Big1)
+	packed, err = uint264Args.Pack(maxUint264)
+	require.NoError(t, err)
+	decoded, err = uint264Args.Unpack(packed)
+	require.NoError(t, err)
+	require.Zero(t, decoded[0].(*big.Int).Cmp(maxUint264))
+	_, err = uint264Args.Pack(new(big.Int).Add(maxUint264, common.Big1))
+	require.ErrorContains(t, err, "uint264")
+	_, err = uint264Args.Unpack(word(new(big.Int).Add(maxUint264, common.Big1)))
+	require.ErrorContains(t, err, "uint264")
 }
 
 func TestPackAndUnpackIncompatibleNumber(t *testing.T) {

--- a/signer/fourbyte/abi_test.go
+++ b/signer/fourbyte/abi_test.go
@@ -176,6 +176,10 @@ func TestCalldataDecoding(t *testing.T) {
 			"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 		// sam with illegal bool byte (tampered copy of samOK).
 		samBadBool,
+		// send(uint256) with bits above 256 set in the 64-byte slot: exceeds
+		// the declared uint256 width.
+		"a52c101e" + "FFffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+			"FFffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 	} {
 		_, err := parseCallData(common.Hex2Bytes(hexdata), jsondata)
 		if err == nil {
@@ -186,8 +190,8 @@ func TestCalldataDecoding(t *testing.T) {
 	for i, hexdata := range []string{
 		samOK,
 		sendOK,
-		// sendOK with high bits set in the uint256 slot (still a valid encoding).
-		"a52c101e" + "FFffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+		// send(MaxUint256): the largest canonical uint256 value.
+		"a52c101e" + "0000000000000000000000000000000000000000000000000000000000000000" +
 			"FFffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 		compareOK,
 		issueOK,


### PR DESCRIPTION
## Summary
- Enforce declared integer widths when decoding: `ReadInteger` now rejects values that exceed the declared `uintN`/`intN` range for all big.Int-backed widths (65–512 bits), instead of returning out-of-range values silently.
- Enforce the same bounds when packing: `packElement` rejects out-of-range values instead of silently encoding them into the 64-byte slot.
- Put the previously dead `MaxUint256`/`MaxInt256` constants to use via shared `fitsUnsignedInteger`/`fitsSignedInteger` helpers.

## Rationale
`ReadInteger`'s default branches returned the raw `*big.Int` with no declared-width check, so a `uint256` slot with bits set above 2^256 decoded "successfully" to a value larger than `MaxUint256`, and an `int256` outside `[MinInt256, MaxInt256]` decoded without error. The pack side had the mirror-image gap: `packNum` wrote whatever fit in 512 bits, so a `uint24` argument of 2^100 encoded silently. Off-chain decode/encode correctness only — no consensus impact — but generated bindings, RPC servers, and clef all consume these paths.

Sign-extension semantics are unchanged: signed values occupy the full 64-byte slot with the sign at bit 511 (matching VM64 SIGNEXTEND and `pack.go`), and bounds apply to the reconstructed value.

Widths that are not multiples of 8 (e.g. `uint17`) remain accepted, matching the type parser inherited from go-ethereum — only the declared-width value range is enforced here. Tightening the parser is a separate concern.

The clef fourbyte calldata fixture that decoded a `send(uint256)` argument with bits above 2^256 (explicitly annotated "still a valid encoding") now expects rejection; the canonical `MaxUint256` encoding covers the success path instead.

Extracted from #68. Closes the last open ABI finding from the VM64 migration audit.

## Tests
- `go test -count=1 ./accounts/abi ./accounts/abi/bind/... ./signer/... ./internal/qrlapi ./qrl/filters ./graphql`